### PR TITLE
Add QR access control views

### DIFF
--- a/ControlesAccesoQR/ControlesAccesoQR.csproj
+++ b/ControlesAccesoQR/ControlesAccesoQR.csproj
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C84C32F9-0000-4000-8000-000000000001}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ControlesAccesoQR</RootNamespace>
+    <AssemblyName>ControlesAccesoQR</AssemblyName>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x64\Debug\</OutputPath>
+    <DefineConstants>CODE_ANALYSIS;DEBUG;TRACE</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <OutputPath>bin\x64\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x64</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+    <Reference Include="System" />
+    <Reference Include="System.Xaml">
+      <RequiredTargetFramework>4.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="WindowsBase" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ViewModels\VistaEntradaSalidaViewModel.cs" />
+    <Compile Include="ViewModels\VistaSalidaFinalViewModel.cs" />
+    <Compile Include="Views\VistaEntradaSalida.xaml.cs">
+      <DependentUpon>VistaEntradaSalida.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\VistaSalidaFinal.xaml.cs">
+      <DependentUpon>VistaSalidaFinal.xaml</DependentUpon>
+    </Compile>
+    <Page Include="Views\VistaEntradaSalida.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\VistaSalidaFinal.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\UI.MVVM\UI.MVVM.csproj">
+      <Project>{52A38E46-A67D-4268-8846-557A4F711E57}</Project>
+      <Name>UI.MVVM</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/ControlesAccesoQR/ViewModels/VistaEntradaSalidaViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/VistaEntradaSalidaViewModel.cs
@@ -1,0 +1,73 @@
+using RECEPTIO.CapaPresentacion.UI.MVVM;
+using System;
+using System.Windows.Input;
+
+namespace ControlesAccesoQR.ViewModels
+{
+    internal class VistaEntradaSalidaViewModel : ViewModelBase
+    {
+        private string _nombre;
+        private string _empresa;
+        private string _patente;
+        private string _horaLlegada;
+        private string _qrSalida;
+
+        public VistaEntradaSalidaViewModel()
+        {
+            ComandoEscanearQr = new RelayCommand(EscanearQr);
+            ComandoIngresar = new RelayCommand(Ingresar);
+            ComandoImprimirQrSalida = new RelayCommand(ImprimirQrSalida);
+        }
+
+        public string Nombre
+        {
+            get => _nombre;
+            set { if (_nombre == value) return; _nombre = value; OnPropertyChanged(nameof(Nombre)); }
+        }
+
+        public string Empresa
+        {
+            get => _empresa;
+            set { if (_empresa == value) return; _empresa = value; OnPropertyChanged(nameof(Empresa)); }
+        }
+
+        public string Patente
+        {
+            get => _patente;
+            set { if (_patente == value) return; _patente = value; OnPropertyChanged(nameof(Patente)); }
+        }
+
+        public string HoraLlegada
+        {
+            get => _horaLlegada;
+            set { if (_horaLlegada == value) return; _horaLlegada = value; OnPropertyChanged(nameof(HoraLlegada)); }
+        }
+
+        public string QrSalida
+        {
+            get => _qrSalida;
+            set { if (_qrSalida == value) return; _qrSalida = value; OnPropertyChanged(nameof(QrSalida)); }
+        }
+
+        public ICommand ComandoEscanearQr { get; }
+        public ICommand ComandoIngresar { get; }
+        public ICommand ComandoImprimirQrSalida { get; }
+
+        private void EscanearQr()
+        {
+            // Lógica de lectura del QR (simulada)
+        }
+
+        private void Ingresar()
+        {
+            HoraLlegada = DateTime.Now.ToString("HH:mm:ss");
+            QrSalida = "placeholder.png";
+            // Aquí debe cambiarse el estado a En Curso en [vhs].[PasePuerta]
+        }
+
+        private void ImprimirQrSalida()
+        {
+            // Lógica de impresión (simulada)
+        }
+    }
+}

--- a/ControlesAccesoQR/ViewModels/VistaSalidaFinalViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/VistaSalidaFinalViewModel.cs
@@ -1,0 +1,74 @@
+using RECEPTIO.CapaPresentacion.UI.MVVM;
+using System;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+
+namespace ControlesAccesoQR.ViewModels
+{
+    internal class VistaSalidaFinalViewModel : ViewModelBase
+    {
+        private string _nombre;
+        private string _empresa;
+        private string _patente;
+        private string _horaSalida;
+        private ObservableCollection<string> _contenedores;
+
+        public VistaSalidaFinalViewModel()
+        {
+            Contenedores = new ObservableCollection<string>();
+            ComandoEscanearQrSalida = new RelayCommand(EscanearQrSalida);
+            ComandoFinalizar = new RelayCommand(Finalizar);
+            ComandoImprimirSalida = new RelayCommand(ImprimirSalida);
+        }
+
+        public string Nombre
+        {
+            get => _nombre;
+            set { if (_nombre == value) return; _nombre = value; OnPropertyChanged(nameof(Nombre)); }
+        }
+
+        public string Empresa
+        {
+            get => _empresa;
+            set { if (_empresa == value) return; _empresa = value; OnPropertyChanged(nameof(Empresa)); }
+        }
+
+        public string Patente
+        {
+            get => _patente;
+            set { if (_patente == value) return; _patente = value; OnPropertyChanged(nameof(Patente)); }
+        }
+
+        public ObservableCollection<string> Contenedores
+        {
+            get => _contenedores;
+            set { if (_contenedores == value) return; _contenedores = value; OnPropertyChanged(nameof(Contenedores)); }
+        }
+
+        public string HoraSalida
+        {
+            get => _horaSalida;
+            set { if (_horaSalida == value) return; _horaSalida = value; OnPropertyChanged(nameof(HoraSalida)); }
+        }
+
+        public ICommand ComandoEscanearQrSalida { get; }
+        public ICommand ComandoFinalizar { get; }
+        public ICommand ComandoImprimirSalida { get; }
+
+        private void EscanearQrSalida()
+        {
+            // Lógica de lectura de QR de salida (simulada)
+        }
+
+        private void Finalizar()
+        {
+            HoraSalida = DateTime.Now.ToString("HH:mm:ss");
+            // Aquí debe cambiarse el estado a Finalizado en [vhs].[PasePuerta]
+        }
+
+        private void ImprimirSalida()
+        {
+            // Lógica de impresión (simulada)
+        }
+    }
+}

--- a/ControlesAccesoQR/Views/VistaEntradaSalida.xaml
+++ b/ControlesAccesoQR/Views/VistaEntradaSalida.xaml
@@ -1,0 +1,20 @@
+<Page x:Class="ControlesAccesoQR.Views.VistaEntradaSalida"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d"
+      Title="VistaEntradaSalida">
+    <Grid Background="{StaticResource StandardBackground}">
+        <StackPanel Margin="20">
+            <Button Content="Escanear QR" Command="{Binding ComandoEscanearQr}" Margin="0,0,0,10" Height="40"/>
+            <TextBlock Text="{Binding Nombre}" FontSize="16"/>
+            <TextBlock Text="{Binding Empresa}" FontSize="16"/>
+            <TextBlock Text="{Binding Patente}" FontSize="16"/>
+            <Button Content="Ingresar" Command="{Binding ComandoIngresar}" Margin="0,10,0,10" Height="40"/>
+            <TextBlock Text="{Binding HoraLlegada}" FontSize="16" Margin="0,0,0,10"/>
+            <Image Source="{Binding QrSalida}" Height="150" Width="150" Margin="0,0,0,10"/>
+            <Button Content="Imprimir QR de Salida" Command="{Binding ComandoImprimirQrSalida}" Height="40"/>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/ControlesAccesoQR/Views/VistaEntradaSalida.xaml.cs
+++ b/ControlesAccesoQR/Views/VistaEntradaSalida.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace ControlesAccesoQR.Views
+{
+    public partial class VistaEntradaSalida : Page
+    {
+        public VistaEntradaSalida()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/ControlesAccesoQR/Views/VistaSalidaFinal.xaml
+++ b/ControlesAccesoQR/Views/VistaSalidaFinal.xaml
@@ -1,0 +1,20 @@
+<Page x:Class="ControlesAccesoQR.Views.VistaSalidaFinal"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d"
+      Title="VistaSalidaFinal">
+    <Grid Background="{StaticResource StandardBackground}">
+        <StackPanel Margin="20">
+            <Button Content="Escanear QR de Salida" Command="{Binding ComandoEscanearQrSalida}" Margin="0,0,0,10" Height="40"/>
+            <TextBlock Text="{Binding Nombre}" FontSize="16"/>
+            <TextBlock Text="{Binding Empresa}" FontSize="16"/>
+            <TextBlock Text="{Binding Patente}" FontSize="16"/>
+            <DataGrid ItemsSource="{Binding Contenedores}" AutoGenerateColumns="True" Height="150" Margin="0,10,0,10"/>
+            <Button Content="Finalizar" Command="{Binding ComandoFinalizar}" Margin="0,0,0,10" Height="40"/>
+            <TextBlock Text="{Binding HoraSalida}" FontSize="16" Margin="0,0,0,10"/>
+            <Button Content="Imprimir Salida" Command="{Binding ComandoImprimirSalida}" Height="40"/>
+        </StackPanel>
+    </Grid>
+</Page>

--- a/ControlesAccesoQR/Views/VistaSalidaFinal.xaml.cs
+++ b/ControlesAccesoQR/Views/VistaSalidaFinal.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace ControlesAccesoQR.Views
+{
+    public partial class VistaSalidaFinal : Page
+    {
+        public VistaSalidaFinal()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/RECEPTIO.sln
+++ b/RECEPTIO.sln
@@ -62,6 +62,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Transaction", "Transaction\
 		{50202ADB-074F-4968-AD7F-E43A9857CDA2} = {50202ADB-074F-4968-AD7F-E43A9857CDA2}
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ControlesAccesoQR", "ControlesAccesoQR\ControlesAccesoQR.csproj", "{C84C32F9-0000-4000-8000-000000000001}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TroubleDeskContrato", "TroubleDeskContrato\TroubleDeskContrato.csproj", "{BD346F16-3EE5-4842-A2FA-C209A1E560A1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mobile.SqlEntityFramework", "Mobile.SqlEntityFramework\Mobile.SqlEntityFramework.csproj", "{B5E5DB62-4FA1-4159-B92B-7DA08428D57D}"
@@ -1430,5 +1432,9 @@ Global
 		SccProjectTopLevelParentUniqueName52 = RECEPTIO.sln
 		SccProjectName52 = TransactionDepot.Servicios
 		SccLocalPath52 = TransactionDepot.Servicios
+                SccProjectUniqueName53 = ControlesAccesoQR\ControlesAccesoQR.csproj
+                SccProjectTopLevelParentUniqueName53 = RECEPTIO.sln
+                SccProjectName53 = ControlesAccesoQR
+                SccLocalPath53 = ControlesAccesoQR
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- introduce new `ControlesAccesoQR` project containing QR access control views and view models
- register the project in `RECEPTIO.sln`
- restore `Transaction.csproj` to its previous state

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887c8bff6708330b03069359194ed7c