### PR TITLE
Add ControlesAccesoQR WPF project

### DIFF
--- a/ControlesAccesoQR/App.xaml
+++ b/ControlesAccesoQR/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="ControlesAccesoQR.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/ControlesAccesoQR/App.xaml.cs
+++ b/ControlesAccesoQR/App.xaml.cs
@@ -1,0 +1,8 @@
+using System.Windows;
+
+namespace ControlesAccesoQR
+{
+    public partial class App : Application
+    {
+    }
+}

--- a/ControlesAccesoQR/ControlesAccesoQR.csproj
+++ b/ControlesAccesoQR/ControlesAccesoQR.csproj
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{EA03C535-BAC7-4EEB-A08D-AADF56A48FF3}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>ControlesAccesoQR</RootNamespace>
+    <AssemblyName>ControlesAccesoQR</AssemblyName>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xaml">
+      <RequiredTargetFramework>4.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="WindowsBase" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </ApplicationDefinition>
+    <Page Include="MainWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\ControlesAccesoQR\VistaEntradaSalida.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\ControlesAccesoQR\VistaSalidaFinal.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Compile Include="App.xaml.cs">
+      <DependentUpon>App.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="MainWindow.xaml.cs">
+      <DependentUpon>MainWindow.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="ViewModels\ControlesAccesoQR\MainWindowViewModel.cs" />
+    <Compile Include="ViewModels\ControlesAccesoQR\VistaEntradaSalidaViewModel.cs" />
+    <Compile Include="ViewModels\ControlesAccesoQR\VistaSalidaFinalViewModel.cs" />
+    <Compile Include="Views\ControlesAccesoQR\VistaEntradaSalida.xaml.cs">
+      <DependentUpon>VistaEntradaSalida.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\ControlesAccesoQR\VistaSalidaFinal.xaml.cs">
+      <DependentUpon>VistaSalidaFinal.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/ControlesAccesoQR/MainWindow.xaml
+++ b/ControlesAccesoQR/MainWindow.xaml
@@ -1,0 +1,14 @@
+<Window x:Class="ControlesAccesoQR.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="ControlesAccesoQR" Height="450" Width="800" WindowStartupLocation="CenterScreen">
+    <Grid>
+        <DockPanel>
+            <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="10">
+                <Button Content="Entrada / Salida" Command="{Binding MostrarEntradaSalidaCommand}" Margin="0,0,10,0"/>
+                <Button Content="Salida Final" Command="{Binding MostrarSalidaFinalCommand}"/>
+            </StackPanel>
+            <Frame x:Name="MainFrame" NavigationUIVisibility="Hidden"/>
+        </DockPanel>
+    </Grid>
+</Window>

--- a/ControlesAccesoQR/MainWindow.xaml.cs
+++ b/ControlesAccesoQR/MainWindow.xaml.cs
@@ -1,0 +1,14 @@
+using System.Windows;
+using ControlesAccesoQR.ViewModels.ControlesAccesoQR;
+
+namespace ControlesAccesoQR
+{
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+            DataContext = new MainWindowViewModel(MainFrame);
+        }
+    }
+}

--- a/ControlesAccesoQR/Properties/AssemblyInfo.cs
+++ b/ControlesAccesoQR/Properties/AssemblyInfo.cs
@@ -1,0 +1,14 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Windows;
+
+[assembly: AssemblyTitle("ControlesAccesoQR")]
+[assembly: AssemblyDescription("Modulo de control de accesos por QR")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("CGSA")]
+[assembly: AssemblyProduct("RECEPTIO")]
+[assembly: AssemblyCopyright("Copyright © CGSA 2018")]
+[assembly: ComVisible(false)]
+[assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
@@ -1,0 +1,32 @@
+using System.Windows.Controls;
+using System.Windows.Input;
+using ControlesAccesoQR.Views.ControlesAccesoQR;
+using RECEPTIO.CapaPresentacion.UI.MVVM;
+
+namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
+{
+    public class MainWindowViewModel : ViewModelBase
+    {
+        private readonly Frame _frame;
+
+        public ICommand MostrarEntradaSalidaCommand { get; }
+        public ICommand MostrarSalidaFinalCommand { get; }
+
+        public MainWindowViewModel(Frame frame)
+        {
+            _frame = frame;
+            MostrarEntradaSalidaCommand = new RelayCommand(MostrarEntradaSalida);
+            MostrarSalidaFinalCommand = new RelayCommand(MostrarSalidaFinal);
+        }
+
+        private void MostrarEntradaSalida()
+        {
+            _frame.Navigate(new VistaEntradaSalida { DataContext = new VistaEntradaSalidaViewModel() });
+        }
+
+        private void MostrarSalidaFinal()
+        {
+            _frame.Navigate(new VistaSalidaFinal { DataContext = new VistaSalidaFinalViewModel() });
+        }
+    }
+}

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Windows.Input;
+using RECEPTIO.CapaPresentacion.UI.MVVM;
+
+namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
+{
+    public class VistaEntradaSalidaViewModel : ViewModelBase
+    {
+        private string _nombre;
+        private string _empresa;
+        private string _patente;
+        private string _horaLlegada;
+        private bool _ingresoRealizado;
+        private string _qrImagePath;
+
+        public string Nombre { get => _nombre; set { _nombre = value; OnPropertyChanged(nameof(Nombre)); } }
+        public string Empresa { get => _empresa; set { _empresa = value; OnPropertyChanged(nameof(Empresa)); } }
+        public string Patente { get => _patente; set { _patente = value; OnPropertyChanged(nameof(Patente)); } }
+        public string HoraLlegada { get => _horaLlegada; set { _horaLlegada = value; OnPropertyChanged(nameof(HoraLlegada)); } }
+        public bool IngresoRealizado { get => _ingresoRealizado; set { _ingresoRealizado = value; OnPropertyChanged(nameof(IngresoRealizado)); } }
+        public string QrImagePath { get => _qrImagePath; set { _qrImagePath = value; OnPropertyChanged(nameof(QrImagePath)); } }
+
+        public ICommand EscanearQrCommand { get; }
+        public ICommand IngresarCommand { get; }
+        public ICommand ImprimirQrCommand { get; }
+
+        public VistaEntradaSalidaViewModel()
+        {
+            EscanearQrCommand = new RelayCommand(EscanearQr);
+            IngresarCommand = new RelayCommand(Ingresar);
+            ImprimirQrCommand = new RelayCommand(ImprimirQr);
+        }
+
+        private void EscanearQr()
+        {
+            // Simulación de escaneo
+            Nombre = "Transportista Demo";
+            Empresa = "Empresa Demo";
+            Patente = "ABC123";
+        }
+
+        private void Ingresar()
+        {
+            HoraLlegada = DateTime.Now.ToString("HH:mm");
+            QrImagePath = "Images/qr_placeholder.png";
+            IngresoRealizado = true;
+            // TODO: Cambiar estado a 'En Curso' en [vhs].[PasePuerta]
+        }
+
+        private void ImprimirQr()
+        {
+            // Lógica de impresión pendiente
+        }
+    }
+}

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaSalidaFinalViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaSalidaFinalViewModel.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+using RECEPTIO.CapaPresentacion.UI.MVVM;
+
+namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
+{
+    public class VistaSalidaFinalViewModel : ViewModelBase
+    {
+        private string _nombre;
+        private string _empresa;
+        private string _patente;
+        private string _horaSalida;
+        private bool _salidaFinalizada;
+
+        public string Nombre { get => _nombre; set { _nombre = value; OnPropertyChanged(nameof(Nombre)); } }
+        public string Empresa { get => _empresa; set { _empresa = value; OnPropertyChanged(nameof(Empresa)); } }
+        public string Patente { get => _patente; set { _patente = value; OnPropertyChanged(nameof(Patente)); } }
+        public string HoraSalida { get => _horaSalida; set { _horaSalida = value; OnPropertyChanged(nameof(HoraSalida)); } }
+        public bool SalidaFinalizada { get => _salidaFinalizada; set { _salidaFinalizada = value; OnPropertyChanged(nameof(SalidaFinalizada)); } }
+
+        public ObservableCollection<string> Contenedores { get; } = new ObservableCollection<string>();
+
+        public ICommand EscanearQrSalidaCommand { get; }
+        public ICommand FinalizarCommand { get; }
+        public ICommand ImprimirSalidaCommand { get; }
+
+        public VistaSalidaFinalViewModel()
+        {
+            EscanearQrSalidaCommand = new RelayCommand(EscanearQrSalida);
+            FinalizarCommand = new RelayCommand(Finalizar);
+            ImprimirSalidaCommand = new RelayCommand(ImprimirSalida);
+
+            Contenedores.Add("CONT-001");
+            Contenedores.Add("CONT-002");
+        }
+
+        private void EscanearQrSalida()
+        {
+            // Simulación de escaneo
+            Nombre = "Transportista Demo";
+            Empresa = "Empresa Demo";
+            Patente = "ABC123";
+        }
+
+        private void Finalizar()
+        {
+            HoraSalida = DateTime.Now.ToString("HH:mm");
+            SalidaFinalizada = true;
+            // TODO: Cambiar estado a 'Finalizado' en [vhs].[PasePuerta]
+        }
+
+        private void ImprimirSalida()
+        {
+            // Lógica de impresión pendiente
+        }
+    }
+}

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
@@ -1,0 +1,20 @@
+<UserControl x:Class="ControlesAccesoQR.Views.ControlesAccesoQR.VistaEntradaSalida"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:conv="clr-namespace:System.Windows.Controls;assembly=PresentationFramework">
+    <UserControl.Resources>
+        <conv:BooleanToVisibilityConverter x:Key="BoolToVis"/>
+    </UserControl.Resources>
+    <StackPanel Margin="20">
+        <Button Content="Escanear QR" Command="{Binding EscanearQrCommand}" Width="150" Margin="0,0,0,10"/>
+        <TextBlock Text="{Binding Nombre, StringFormat=Nombre: {0}}" Margin="0,0,0,5"/>
+        <TextBlock Text="{Binding Empresa, StringFormat=Empresa: {0}}" Margin="0,0,0,5"/>
+        <TextBlock Text="{Binding Patente, StringFormat=Patente: {0}}" Margin="0,0,0,10"/>
+        <Button Content="Ingresar" Command="{Binding IngresarCommand}" Width="100" Margin="0,0,0,10"/>
+        <StackPanel Visibility="{Binding IngresoRealizado, Converter={StaticResource BoolToVis}}">
+            <TextBlock Text="{Binding HoraLlegada, StringFormat=Hora de llegada: {0}}" Margin="0,0,0,5"/>
+            <Image Source="{Binding QrImagePath}" Height="100" Width="100" Margin="0,0,0,5"/>
+            <Button Content="Imprimir QR de Salida" Command="{Binding ImprimirQrCommand}" Width="180"/>
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace ControlesAccesoQR.Views.ControlesAccesoQR
+{
+    public partial class VistaEntradaSalida : UserControl
+    {
+        public VistaEntradaSalida()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
@@ -1,0 +1,20 @@
+<UserControl x:Class="ControlesAccesoQR.Views.ControlesAccesoQR.VistaSalidaFinal"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:conv="clr-namespace:System.Windows.Controls;assembly=PresentationFramework">
+    <UserControl.Resources>
+        <conv:BooleanToVisibilityConverter x:Key="BoolToVis"/>
+    </UserControl.Resources>
+    <StackPanel Margin="20">
+        <Button Content="Escanear QR de Salida" Command="{Binding EscanearQrSalidaCommand}" Width="180" Margin="0,0,0,10"/>
+        <TextBlock Text="{Binding Nombre, StringFormat=Nombre: {0}}" Margin="0,0,0,5"/>
+        <TextBlock Text="{Binding Empresa, StringFormat=Empresa: {0}}" Margin="0,0,0,5"/>
+        <TextBlock Text="{Binding Patente, StringFormat=Patente: {0}}" Margin="0,0,0,10"/>
+        <DataGrid ItemsSource="{Binding Contenedores}" AutoGenerateColumns="True" Height="100" Margin="0,0,0,10"/>
+        <Button Content="Finalizar" Command="{Binding FinalizarCommand}" Width="120" Margin="0,0,0,10"/>
+        <StackPanel Visibility="{Binding SalidaFinalizada, Converter={StaticResource BoolToVis}}">
+            <TextBlock Text="{Binding HoraSalida, StringFormat=Hora de salida: {0}}" Margin="0,0,0,5"/>
+            <Button Content="Imprimir Salida" Command="{Binding ImprimirSalidaCommand}" Width="150"/>
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml.cs
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows.Controls;
+
+namespace ControlesAccesoQR.Views.ControlesAccesoQR
+{
+    public partial class VistaSalidaFinal : UserControl
+    {
+        public VistaSalidaFinal()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/RECEPTIO.sln
+++ b/RECEPTIO.sln
@@ -286,6 +286,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TransactionDepot.Servicios"
 		{50202ADB-074F-4968-AD7F-E43A9857CDA2} = {50202ADB-074F-4968-AD7F-E43A9857CDA2}
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ControlesAccesoQR", "ControlesAccesoQR\ControlesAccesoQR.csproj", "{EA03C535-BAC7-4EEB-A08D-AADF56A48FF3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1218,7 +1220,7 @@ Global
 		SolutionGuid = {6482C79A-ED9C-440A-8DDB-85E73FE10CFD}
 	EndGlobalSection
 	GlobalSection(TeamFoundationVersionControl) = preSolution
-		SccNumberOfProjects = 53
+		SccNumberOfProjects = 54
 		SccEnterpriseProvider = {4CA58AB2-18FA-4F8D-95D4-32DDF27D184C}
 		SccTeamFoundationServer = https://desarrolloitcgsa.visualstudio.com/
 		SccLocalPath0 = .
@@ -1430,5 +1432,9 @@ Global
 		SccProjectTopLevelParentUniqueName52 = RECEPTIO.sln
 		SccProjectName52 = TransactionDepot.Servicios
 		SccLocalPath52 = TransactionDepot.Servicios
+                SccProjectUniqueName53 = ControlesAccesoQR\ControlesAccesoQR.csproj
+                SccProjectTopLevelParentUniqueName53 = RECEPTIO.sln
+                SccProjectName53 = ControlesAccesoQR
+                SccLocalPath53 = ControlesAccesoQR
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- create new `ControlesAccesoQR` WPF project under presentation layer
- add starter views `VistaEntradaSalida` and `VistaSalidaFinal`
- implement associated ViewModels with placeholder logic
- include navigation from `MainWindow`
- register the project inside `RECEPTIO.sln`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887df116fbc8330ae8005d6fbd076a9