### PR TITLE
Apply PaginaInicio styling to QR control views

### DIFF
--- a/ControlesAccesoQR/MainWindow.xaml
+++ b/ControlesAccesoQR/MainWindow.xaml
@@ -1,14 +1,29 @@
 <Window x:Class="ControlesAccesoQR.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="ControlesAccesoQR" Height="450" Width="800" WindowStartupLocation="CenterScreen">
-    <Grid>
+        Title="ControlesAccesoQR"
+        Height="450"
+        Width="800"
+        WindowStartupLocation="CenterScreen"
+        FontFamily="Microsoft Sans Serif">
+    <Window.Resources>
+        <LinearGradientBrush x:Key="StandardBackground" EndPoint="0.504,1.5" StartPoint="0.504,0.03">
+            <GradientStop Color="#FFFFFF" Offset="0" />
+            <GradientStop Color="#FFFFFF" Offset="0.567" />
+        </LinearGradientBrush>
+        <Style TargetType="Button">
+            <Setter Property="Background" Value="#EF6C00" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="FontSize" Value="20" />
+        </Style>
+    </Window.Resources>
+    <Grid Background="{StaticResource StandardBackground}">
         <DockPanel>
             <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="10">
-                <Button Content="Entrada / Salida" Command="{Binding MostrarEntradaSalidaCommand}" Margin="0,0,10,0"/>
-                <Button Content="Salida Final" Command="{Binding MostrarSalidaFinalCommand}"/>
+                <Button Content="Entrada / Salida" Command="{Binding MostrarEntradaSalidaCommand}" Margin="0,0,10,0" />
+                <Button Content="Salida Final" Command="{Binding MostrarSalidaFinalCommand}" />
             </StackPanel>
-            <Frame x:Name="MainFrame" NavigationUIVisibility="Hidden"/>
+            <Frame x:Name="MainFrame" NavigationUIVisibility="Hidden" />
         </DockPanel>
     </Grid>
 </Window>

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
@@ -1,20 +1,35 @@
 <UserControl x:Class="ControlesAccesoQR.Views.ControlesAccesoQR.VistaEntradaSalida"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:conv="clr-namespace:System.Windows.Controls;assembly=PresentationFramework">
+             xmlns:conv="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
+             FontFamily="Microsoft Sans Serif">
     <UserControl.Resources>
-        <conv:BooleanToVisibilityConverter x:Key="BoolToVis"/>
+        <conv:BooleanToVisibilityConverter x:Key="BoolToVis" />
+        <LinearGradientBrush x:Key="StandardBackground" EndPoint="0.504,1.5" StartPoint="0.504,0.03">
+            <GradientStop Color="#FFFFFF" Offset="0" />
+            <GradientStop Color="#FFFFFF" Offset="0.567" />
+        </LinearGradientBrush>
+        <Style TargetType="Button">
+            <Setter Property="Background" Value="#EF6C00" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="FontSize" Value="20" />
+        </Style>
+        <Style TargetType="TextBlock">
+            <Setter Property="FontSize" Value="20" />
+        </Style>
     </UserControl.Resources>
-    <StackPanel Margin="20">
-        <Button Content="Escanear QR" Command="{Binding EscanearQrCommand}" Width="150" Margin="0,0,0,10"/>
-        <TextBlock Text="{Binding Nombre, StringFormat=Nombre: {0}}" Margin="0,0,0,5"/>
-        <TextBlock Text="{Binding Empresa, StringFormat=Empresa: {0}}" Margin="0,0,0,5"/>
-        <TextBlock Text="{Binding Patente, StringFormat=Patente: {0}}" Margin="0,0,0,10"/>
-        <Button Content="Ingresar" Command="{Binding IngresarCommand}" Width="100" Margin="0,0,0,10"/>
-        <StackPanel Visibility="{Binding IngresoRealizado, Converter={StaticResource BoolToVis}}">
-            <TextBlock Text="{Binding HoraLlegada, StringFormat=Hora de llegada: {0}}" Margin="0,0,0,5"/>
-            <Image Source="{Binding QrImagePath}" Height="100" Width="100" Margin="0,0,0,5"/>
-            <Button Content="Imprimir QR de Salida" Command="{Binding ImprimirQrCommand}" Width="180"/>
+    <Grid Background="{StaticResource StandardBackground}">
+        <StackPanel Margin="20">
+            <Button Content="Escanear QR" Command="{Binding EscanearQrCommand}" Width="150" Margin="0,0,0,10" />
+            <TextBlock Text="{Binding Nombre, StringFormat=Nombre: {0}}" Margin="0,0,0,5" />
+            <TextBlock Text="{Binding Empresa, StringFormat=Empresa: {0}}" Margin="0,0,0,5" />
+            <TextBlock Text="{Binding Patente, StringFormat=Patente: {0}}" Margin="0,0,0,10" />
+            <Button Content="Ingresar" Command="{Binding IngresarCommand}" Width="100" Margin="0,0,0,10" />
+            <StackPanel Visibility="{Binding IngresoRealizado, Converter={StaticResource BoolToVis}}">
+                <TextBlock Text="{Binding HoraLlegada, StringFormat=Hora de llegada: {0}}" Margin="0,0,0,5" />
+                <Image Source="{Binding QrImagePath}" Height="100" Width="100" Margin="0,0,0,5" />
+                <Button Content="Imprimir QR de Salida" Command="{Binding ImprimirQrCommand}" Width="180" />
+            </StackPanel>
         </StackPanel>
-    </StackPanel>
+    </Grid>
 </UserControl>

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
@@ -1,20 +1,35 @@
 <UserControl x:Class="ControlesAccesoQR.Views.ControlesAccesoQR.VistaSalidaFinal"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:conv="clr-namespace:System.Windows.Controls;assembly=PresentationFramework">
+             xmlns:conv="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
+             FontFamily="Microsoft Sans Serif">
     <UserControl.Resources>
-        <conv:BooleanToVisibilityConverter x:Key="BoolToVis"/>
+        <conv:BooleanToVisibilityConverter x:Key="BoolToVis" />
+        <LinearGradientBrush x:Key="StandardBackground" EndPoint="0.504,1.5" StartPoint="0.504,0.03">
+            <GradientStop Color="#FFFFFF" Offset="0" />
+            <GradientStop Color="#FFFFFF" Offset="0.567" />
+        </LinearGradientBrush>
+        <Style TargetType="Button">
+            <Setter Property="Background" Value="#EF6C00" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="FontSize" Value="20" />
+        </Style>
+        <Style TargetType="TextBlock">
+            <Setter Property="FontSize" Value="20" />
+        </Style>
     </UserControl.Resources>
-    <StackPanel Margin="20">
-        <Button Content="Escanear QR de Salida" Command="{Binding EscanearQrSalidaCommand}" Width="180" Margin="0,0,0,10"/>
-        <TextBlock Text="{Binding Nombre, StringFormat=Nombre: {0}}" Margin="0,0,0,5"/>
-        <TextBlock Text="{Binding Empresa, StringFormat=Empresa: {0}}" Margin="0,0,0,5"/>
-        <TextBlock Text="{Binding Patente, StringFormat=Patente: {0}}" Margin="0,0,0,10"/>
-        <DataGrid ItemsSource="{Binding Contenedores}" AutoGenerateColumns="True" Height="100" Margin="0,0,0,10"/>
-        <Button Content="Finalizar" Command="{Binding FinalizarCommand}" Width="120" Margin="0,0,0,10"/>
-        <StackPanel Visibility="{Binding SalidaFinalizada, Converter={StaticResource BoolToVis}}">
-            <TextBlock Text="{Binding HoraSalida, StringFormat=Hora de salida: {0}}" Margin="0,0,0,5"/>
-            <Button Content="Imprimir Salida" Command="{Binding ImprimirSalidaCommand}" Width="150"/>
+    <Grid Background="{StaticResource StandardBackground}">
+        <StackPanel Margin="20">
+            <Button Content="Escanear QR de Salida" Command="{Binding EscanearQrSalidaCommand}" Width="180" Margin="0,0,0,10" />
+            <TextBlock Text="{Binding Nombre, StringFormat=Nombre: {0}}" Margin="0,0,0,5" />
+            <TextBlock Text="{Binding Empresa, StringFormat=Empresa: {0}}" Margin="0,0,0,5" />
+            <TextBlock Text="{Binding Patente, StringFormat=Patente: {0}}" Margin="0,0,0,10" />
+            <DataGrid ItemsSource="{Binding Contenedores}" AutoGenerateColumns="True" Height="100" Margin="0,0,0,10" />
+            <Button Content="Finalizar" Command="{Binding FinalizarCommand}" Width="120" Margin="0,0,0,10" />
+            <StackPanel Visibility="{Binding SalidaFinalizada, Converter={StaticResource BoolToVis}}">
+                <TextBlock Text="{Binding HoraSalida, StringFormat=Hora de salida: {0}}" Margin="0,0,0,5" />
+                <Button Content="Imprimir Salida" Command="{Binding ImprimirSalidaCommand}" Width="150" />
+            </StackPanel>
         </StackPanel>
-    </StackPanel>
+    </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- restyle QR application views to match the PaginaInicio look

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj -c Release` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6887e7d99c48833086ef3c503ef886d7