### PR TITLE
Fetch driver and company names

### DIFF
--- a/ControlesAccesoQR/App.config
+++ b/ControlesAccesoQR/App.config
@@ -2,5 +2,7 @@
 <configuration>
   <connectionStrings>
     <add name="midle" connectionString="Data Source=CGDES12;Initial Catalog=N4Middleware;Persist Security Info=True;User ID=n4;Password=n4test;Connection Timeout=120" providerName="System.Data.SqlClient" />
+    <!-- Connection string used to fetch extended information like driver and company names -->
+    <add name="n4catalog" connectionString="data source=cgdes12;initial catalog=RECEPTIO;persist security info=True;user id=n4;password=n4test;MultipleActiveResultSets=True;App=EntityFramework" providerName="System.Data.SqlClient" />
   </connectionStrings>
 </configuration>


### PR DESCRIPTION
## Summary
- extend `PasePuertaInfo` with full driver and company names
- add helper for second connection string
- query `[Bill].[compania_lista]` and `[Bill].[choferes_empresa_lista]` using the catalog database
- register catalog connection string in `App.config`

## Testing
- `dotnet test RECEPTIO.sln --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889181a57d883309705aeb9daf82f8e