### PR TITLE
Add driver/company name lookup in QR access

### DIFF
--- a/ControlesAccesoQR/App.config
+++ b/ControlesAccesoQR/App.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <connectionStrings>
-    <add name="midle" connectionString="Data Source=CGDES12;Initial Catalog=N4Middleware;Persist Security Info=True;User ID=n4;Password=n4test;Connection Timeout=120" providerName="System.Data.SqlClient" />
+    <add name="midle" connectionString="Data Source=cgdes11;Initial Catalog=N5;User ID=n4;Password=n4test;Connection Timeout=0" providerName="System.Data.SqlClient" />
+    <add name="bill" connectionString="Data Source=CGDES12;Initial Catalog=RECEPTIO;Persist Security Info=True;User ID=n4;Password=n4test;Connection Timeout=120" providerName="System.Data.SqlClient" />
   </connectionStrings>
 </configuration>

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
@@ -46,8 +46,8 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
             var datos = _dataAccess.ObtenerChoferEmpresaPorPase(NumeroPase);
             if (datos != null)
             {
-                Nombre = datos.Nombre;
-                Empresa = datos.Empresa;
+                Nombre = datos.ChoferNombre;
+                Empresa = datos.EmpresaNombre;
                 Patente = datos.Patente;
             }
         }


### PR DESCRIPTION
## Summary
- extend `PasePuertaInfo` with id and name fields
- add secondary connection string `bill`
- query stored procedures to resolve driver and company names
- show real names in the QR view model
- use the provided base connection string for ID lookups

## Testing
- `dotnet test` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68892423e8ac8330b80a04469053557f