### PR TITLE
Maintain process panel state

### DIFF
--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
@@ -12,6 +12,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         private readonly Frame _frame;
 
         private EstadoProceso _estadoProceso = EstadoProceso.EnEspera;
+        private EstadoProceso _ultimoEstadoVisible = EstadoProceso.EnEspera;
         private PaseProcesoModel _paseActual;
 
         public ICommand MostrarEntradaSalidaCommand { get; }
@@ -20,7 +21,19 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         public EstadoProceso EstadoProceso
         {
             get => _estadoProceso;
-            set { _estadoProceso = value; OnPropertyChanged(nameof(EstadoProceso)); }
+            set
+            {
+                _estadoProceso = value;
+                OnPropertyChanged(nameof(EstadoProceso));
+                if (value != EstadoProceso.EnEspera)
+                    UltimoEstadoVisible = value;
+            }
+        }
+
+        public EstadoProceso UltimoEstadoVisible
+        {
+            get => _ultimoEstadoVisible;
+            private set { _ultimoEstadoVisible = value; OnPropertyChanged(nameof(UltimoEstadoVisible)); }
         }
 
         public PaseProcesoModel PaseActual
@@ -49,7 +62,6 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         public async Task ReiniciarDespuesDeSalidaAsync()
         {
             await Task.Delay(5000);
-            PaseActual = null;
             EstadoProceso = EstadoProceso.EnEspera;
         }
     }

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/EstadoProcesoPanel.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/EstadoProcesoPanel.xaml
@@ -5,25 +5,29 @@
              FontFamily="Microsoft Sans Serif">
     <UserControl.Resources>
         <DataTemplate x:Key="EnEsperaTemplate">
-            <StackPanel Margin="10" HorizontalAlignment="Center" VerticalAlignment="Center">
-                <TextBlock Text="📥 Esperando escaneo..." FontSize="20" />
-            </StackPanel>
+            <Border Background="#FF9800" Padding="10">
+                <TextBlock Text="📥 Esperando escaneo..." Foreground="White" FontSize="24" TextAlignment="Center"/>
+            </Border>
         </DataTemplate>
         <DataTemplate x:Key="IngresoTemplate">
-            <StackPanel Margin="10">
-                <TextBlock Text="✅ Ingreso registrado" FontSize="20" Margin="0,0,0,5" />
-                <TextBlock Text="{Binding PaseActual.NombreChofer, StringFormat=Nombre: {0}}" />
-                <TextBlock Text="{Binding PaseActual.Placa, StringFormat=Placa: {0}}" />
-                <TextBlock Text="{Binding PaseActual.FechaHoraLlegada, StringFormat=Llegada: {0:G}}" />
-            </StackPanel>
+            <Border Background="#4CAF50" Padding="10">
+                <StackPanel>
+                    <TextBlock Text="✅ Ingreso registrado" FontSize="24" Foreground="White" Margin="0,0,0,5" />
+                    <TextBlock Text="{Binding PaseActual.NombreChofer, StringFormat=Nombre: {0}}" Foreground="White" />
+                    <TextBlock Text="{Binding PaseActual.Placa, StringFormat=Placa: {0}}" Foreground="White" />
+                    <TextBlock Text="{Binding PaseActual.FechaHoraLlegada, StringFormat=Llegada: {0:G}}" Foreground="White" />
+                </StackPanel>
+            </Border>
         </DataTemplate>
         <DataTemplate x:Key="SalidaTemplate">
-            <StackPanel Margin="10">
-                <TextBlock Text="✅ Salida registrada" FontSize="20" Margin="0,0,0,5" />
-                <TextBlock Text="{Binding PaseActual.NombreChofer, StringFormat=Nombre: {0}}" />
-                <TextBlock Text="{Binding PaseActual.Placa, StringFormat=Placa: {0}}" />
-                <TextBlock Text="{Binding PaseActual.FechaHoraSalida, StringFormat=Salida: {0:G}}" />
-            </StackPanel>
+            <Border Background="#8BC34A" Padding="10">
+                <StackPanel>
+                    <TextBlock Text="✅ Proceso completado" FontSize="24" Foreground="White" Margin="0,0,0,5" />
+                    <TextBlock Text="{Binding PaseActual.NombreChofer, StringFormat=Nombre: {0}}" Foreground="White" />
+                    <TextBlock Text="{Binding PaseActual.Placa, StringFormat=Placa: {0}}" Foreground="White" />
+                    <TextBlock Text="{Binding PaseActual.FechaHoraSalida, StringFormat=Salida: {0:G}}" Foreground="White" />
+                </StackPanel>
+            </Border>
         </DataTemplate>
     </UserControl.Resources>
     <Grid>
@@ -32,10 +36,10 @@
                 <Style TargetType="ContentControl">
                     <Setter Property="ContentTemplate" Value="{StaticResource EnEsperaTemplate}" />
                     <Style.Triggers>
-                        <DataTrigger Binding="{Binding EstadoProceso}" Value="{x:Static models:EstadoProceso.IngresoRegistrado}">
+                        <DataTrigger Binding="{Binding UltimoEstadoVisible}" Value="{x:Static models:EstadoProceso.IngresoRegistrado}">
                             <Setter Property="ContentTemplate" Value="{StaticResource IngresoTemplate}" />
                         </DataTrigger>
-                        <DataTrigger Binding="{Binding EstadoProceso}" Value="{x:Static models:EstadoProceso.SalidaRegistrada}">
+                        <DataTrigger Binding="{Binding UltimoEstadoVisible}" Value="{x:Static models:EstadoProceso.SalidaRegistrada}">
                             <Setter Property="ContentTemplate" Value="{StaticResource SalidaTemplate}" />
                         </DataTrigger>
                     </Style.Triggers>


### PR DESCRIPTION
## Summary
- track last state in `MainWindowViewModel`
- use the new `UltimoEstadoVisible` property in `EstadoProcesoPanel`
- apply solid colored backgrounds with big white text
- keep process summary visible after completing salida

## Testing
- `dotnet build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a56bab63c8330b48d2749088acd48