### PR TITLE
Fix EstadoProceso implementation and ambiguous enum

### DIFF
--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/EstadoEnEspera.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/EstadoEnEspera.cs
@@ -1,0 +1,19 @@
+using System.Windows;
+
+namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
+{
+    internal class EstadoEnEspera : EstadoProceso
+    {
+        internal override void EstablecerControles(MainWindowViewModel viewModel)
+        {
+            Titulo = "EN ESPERA";
+            Mensaje = string.Empty;
+            EsVisibleBoton = Visibility.Collapsed;
+        }
+
+        internal override void CambiarEstado()
+        {
+            // No cambia automáticamente a otro estado
+        }
+    }
+}

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/EstadoIngresoRegistrado.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/EstadoIngresoRegistrado.cs
@@ -1,0 +1,18 @@
+using System.Windows;
+
+namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
+{
+    internal class EstadoIngresoRegistrado : EstadoProceso
+    {
+        internal override void EstablecerControles(MainWindowViewModel viewModel)
+        {
+            Titulo = "INGRESO REGISTRADO";
+            EsVisibleBoton = Visibility.Collapsed;
+        }
+
+        internal override void CambiarEstado()
+        {
+            // No se avanza automáticamente en este ejemplo
+        }
+    }
+}

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/EstadoProceso.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/EstadoProceso.cs
@@ -47,5 +47,9 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
 
         internal abstract void EstablecerControles(MainWindowViewModel viewModel);
         internal abstract void CambiarEstado();
+
+        internal static EstadoProceso EnEspera => new EstadoEnEspera();
+        internal static EstadoProceso IngresoRegistrado => new EstadoIngresoRegistrado();
+        internal static EstadoProceso SalidaRegistrada => new EstadoSalidaRegistrada();
     }
 }

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/EstadoSalidaRegistrada.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/EstadoSalidaRegistrada.cs
@@ -1,0 +1,18 @@
+using System.Windows;
+
+namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
+{
+    internal class EstadoSalidaRegistrada : EstadoProceso
+    {
+        internal override void EstablecerControles(MainWindowViewModel viewModel)
+        {
+            Titulo = "SALIDA REGISTRADA";
+            EsVisibleBoton = Visibility.Collapsed;
+        }
+
+        internal override void CambiarEstado()
+        {
+            // Una vez registrada la salida, no hay cambio automático
+        }
+    }
+}

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
@@ -4,6 +4,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using ControlesAccesoQR.Views.ControlesAccesoQR;
 using ControlesAccesoQR.Models;
+using EstadoProcesoTipo = ControlesAccesoQR.Models.EstadoProceso;
 using RECEPTIO.CapaPresentacion.UI.MVVM;
 
 namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
@@ -5,6 +5,7 @@ using QRCoder;
 using RECEPTIO.CapaPresentacion.UI.MVVM;
 using ControlesAccesoQR.accesoDatos;
 using ControlesAccesoQR.Models;
+using EstadoProcesoTipo = ControlesAccesoQR.Models.EstadoProceso;
 
 namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
 {
@@ -92,7 +93,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
                 Placa = Patente,
                 FechaHoraLlegada = HoraLlegada,
                 NumeroPase = NumeroPase,
-                Estado = EstadoProceso.EnEspera
+                Estado = EstadoProcesoTipo.EnEspera
             };
         }
 

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaSalidaFinalViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaSalidaFinalViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.ObjectModel;
 using System.Windows.Input;
 using ControlesAccesoQR.accesoDatos;
 using ControlesAccesoQR.Models;
+using EstadoProcesoTipo = ControlesAccesoQR.Models.EstadoProceso;
 using RECEPTIO.CapaPresentacion.UI.MVVM;
 
 namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
@@ -91,7 +92,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
                     Placa = Patente,
                     FechaHoraSalida = resultado.FechaHoraSalida,
                     NumeroPase = resultado.NumeroPase,
-                    Estado = EstadoProceso.SalidaRegistrada
+                    Estado = EstadoProcesoTipo.SalidaRegistrada
                 };
                 _mainViewModel.EstadoProceso = EstadoProceso.SalidaRegistrada;
                 _ = _mainViewModel.ReiniciarDespuesDeSalidaAsync();

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
@@ -3,6 +3,7 @@ using System.Windows.Controls;
 using ControlesAccesoQR.ViewModels.ControlesAccesoQR;
 using ControlesAccesoQR.Views.ControlesAccesoQR;
 using ControlesAccesoQR.Models;
+using EstadoProcesoTipo = ControlesAccesoQR.Models.EstadoProceso;
 
 namespace ControlesAccesoQR.Views.ControlesAccesoQR
 {


### PR DESCRIPTION
## Summary
- add concrete state classes for EnEspera, IngresoRegistrado and SalidaRegistrada
- expose static factories in `EstadoProceso`
- alias `ControlesAccesoQR.Models.EstadoProceso` to avoid name conflict
- update view models to use the new types

## Testing
- `msbuild RECEPTIO.sln -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d311724f08330a0c9b671a5eb4f8b