### PR TITLE
Fix missing enum using and method visibility

### DIFF
--- a/ControlesAccesoQR/ControlesAccesoQR.csproj
+++ b/ControlesAccesoQR/ControlesAccesoQR.csproj
@@ -48,6 +48,12 @@
     <Reference Include="QRCoder, Version=1.6.0.0, Culture=neutral, PublicKeyToken=c4ed5b9ae8358a28, processorArchitecture=MSIL">
       <HintPath>..\packages\QRCoder.1.6.0\lib\net40\QRCoder.dll</HintPath>
     </Reference>
+    <Reference Include="Spring.Aop">
+      <HintPath>..\Recursos\Spring.Aop.dll</HintPath>
+    </Reference>
+    <Reference Include="Spring.Core">
+      <HintPath>..\Recursos\Spring.Core.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
@@ -5,7 +5,7 @@ using System.Windows.Input;
 using ControlesAccesoQR.Views.ControlesAccesoQR;
 using ControlesAccesoQR.Models;
 
-using EstadoProcesoTipo = ControlesAccesoQR.Models.EstadoProceso;
+using EstadoProcesoEnum = ControlesAccesoQR.Models.EstadoProceso;
 
 using RECEPTIO.CapaPresentacion.UI.MVVM;
 

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/PaginaRfidViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/PaginaRfidViewModel.cs
@@ -79,7 +79,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
             _antena.DesconectarAntena();
         }
 
-        protected override void CambiarEstado()
+        internal override void CambiarEstado()
         {
             // Se podr\u00eda avanzar a otro paso si existiera.
         }


### PR DESCRIPTION
## Summary
- add Spring library references to `ControlesAccesoQR`
- expose `EstadoProcesoEnum` alias for main window view model
- override `CambiarEstado` with correct visibility

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d3cc145ec833085864295f13c754d