### PR TITLE
Fix missing state classes in ControlesAccesoQR

### DIFF
--- a/ControlesAccesoQR/ControlesAccesoQR.csproj
+++ b/ControlesAccesoQR/ControlesAccesoQR.csproj
@@ -112,6 +112,10 @@
     <Compile Include="Models\PaseProcesoModel.cs" />
     <Compile Include="Models\Proceso.cs" />
     <Compile Include="ViewModels\ControlesAccesoQR\EstadoProceso.cs" />
+    <Compile Include="ViewModels\ControlesAccesoQR\EstadoEnEspera.cs" />
+    <Compile Include="ViewModels\ControlesAccesoQR\EstadoIngresoRegistrado.cs" />
+    <Compile Include="ViewModels\ControlesAccesoQR\EstadoSalidaRegistrada.cs" />
+    <Compile Include="ViewModels\ControlesAccesoQR\EstadoProceso.Estaticos.cs" />
     <Compile Include="ViewModels\ControlesAccesoQR\PaginaRfidViewModel.cs" />
     <Compile Include="ViewModels\ControlesAccesoQR\HuellaViewModel.cs" />
     <Compile Include="Views\ControlesAccesoQR\VistaEntradaSalida.xaml.cs">


### PR DESCRIPTION
## Summary
- include state view model files in the ControlesAccesoQR project so references to `EstadoEnEspera`, `EstadoIngresoRegistrado`, and `EstadoSalidaRegistrada` resolve

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d423787a08330b27253533b7704ac