### PR TITLE
Rename Entrada button and embed inline QR scan textbox

### DIFF
--- a/ControlesAccesoQR/MainWindow.xaml
+++ b/ControlesAccesoQR/MainWindow.xaml
@@ -25,7 +25,7 @@
         </Grid.ColumnDefinitions>
         <DockPanel Grid.Column="0">
             <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="10">
-                <Button Content="Entrada / Salida" Command="{Binding MostrarEntradaSalidaCommand}" Margin="0,0,10,0" />
+                <Button Content="Entrada" Command="{Binding MostrarEntradaSalidaCommand}" Margin="0,0,10,0" />
                 <Button Content="Salida Final" Command="{Binding MostrarSalidaFinalCommand}" />
             </StackPanel>
             <Frame x:Name="MainFrame" NavigationUIVisibility="Hidden" />

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
@@ -34,7 +34,16 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         public DateTime HoraLlegada { get => _horaLlegada; set { _horaLlegada = value; OnPropertyChanged(nameof(HoraLlegada)); } }
         public bool IngresoRealizado { get => _ingresoRealizado; set { _ingresoRealizado = value; OnPropertyChanged(nameof(IngresoRealizado)); } }
         public string QrImagePath { get => _qrImagePath; set { _qrImagePath = value; OnPropertyChanged(nameof(QrImagePath)); } }
-        public string NumeroPase { get => _numeroPase; set { _numeroPase = value; OnPropertyChanged(nameof(NumeroPase)); } }
+        public string NumeroPase
+        {
+            get => _numeroPase;
+            set
+            {
+                _numeroPase = value;
+                OnPropertyChanged(nameof(NumeroPase));
+                EscanearQr();
+            }
+        }
 
         public ICommand EscanearQrCommand { get; }
         public ICommand IngresarCommand { get; }

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
@@ -20,7 +20,8 @@
     </UserControl.Resources>
     <Grid Background="{StaticResource StandardBackground}">
         <StackPanel Margin="20">
-            <Button Content="Escanear QR" Command="{Binding EscanearQrCommand}" Width="150" Margin="0,0,0,10" Click="EscanearQrButton_Click" />
+            <Button Content="Escanear QR" Command="{Binding EscanearQrCommand}" Width="150" Margin="0,0,0,10" />
+            <TextBox x:Name="NumeroPaseTextBox" Text="{Binding NumeroPase, UpdateSourceTrigger=PropertyChanged}" Width="200" Margin="0,0,0,10" Loaded="NumeroPaseTextBox_Loaded" />
             <TextBlock Text="{Binding Nombre, StringFormat=Nombre: {0}}" Margin="0,0,0,5" />
             <TextBlock Text="{Binding Empresa, StringFormat=Empresa: {0}}" Margin="0,0,0,5" />
            

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
@@ -1,7 +1,6 @@
 using System.Windows;
 using System.Windows.Controls;
 using ControlesAccesoQR.ViewModels.ControlesAccesoQR;
-using ControlesAccesoQR.Views.ControlesAccesoQR;
 using ControlesAccesoQR.Models;
 using EstadoProcesoTipo = ControlesAccesoQR.Models.EstadoProceso;
 
@@ -12,20 +11,6 @@ namespace ControlesAccesoQR.Views.ControlesAccesoQR
         public VistaEntradaSalida()
         {
             InitializeComponent();
-        }
-
-        private void EscanearQrButton_Click(object sender, RoutedEventArgs e)
-        {
-            var dialogo = new DialogoQr { Owner = Window.GetWindow(this) };
-            if (dialogo.ShowDialog() == true)
-            {
-                if (DataContext is VistaEntradaSalidaViewModel vm)
-                {
-                    vm.NumeroPase = dialogo.NumeroPase;
-                    if (vm.EscanearQrCommand.CanExecute(null))
-                        vm.EscanearQrCommand.Execute(null);
-                }
-            }
         }
 
         private void IngresarButton_Click(object sender, RoutedEventArgs e)
@@ -52,6 +37,11 @@ namespace ControlesAccesoQR.Views.ControlesAccesoQR
                     }
                 }
             }
+        }
+
+        private void NumeroPaseTextBox_Loaded(object sender, RoutedEventArgs e)
+        {
+            ((TextBox)sender).Focus();
         }
     }
 }


### PR DESCRIPTION
## Summary
- Rename the Entrada/Salida button to Entrada
- Replace QR scan popup with inline textbox that autoprocesses codes and focuses automatically

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(missing package)*

------
https://chatgpt.com/codex/tasks/task_e_688fc2a4dd288330a1ea66f383ac28f2