### PR TITLE
Add reusable numeric keyboard control

### DIFF
--- a/ControlesAccesoQR/ControlesAccesoQR.csproj
+++ b/ControlesAccesoQR/ControlesAccesoQR.csproj
@@ -79,6 +79,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="UserControls\TecladoNumerico.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="Views\ControlesAccesoQR\VistaEntradaSalida.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -104,6 +108,9 @@
     </Compile>
     <Compile Include="MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="UserControls\TecladoNumerico.xaml.cs">
+      <DependentUpon>TecladoNumerico.xaml</DependentUpon>
     </Compile>
     <Compile Include="ViewModels\ControlesAccesoQR\MainWindowViewModel.cs" />
     <Compile Include="ViewModels\ControlesAccesoQR\VistaEntradaSalidaViewModel.cs" />

--- a/ControlesAccesoQR/UserControls/TecladoNumerico.xaml
+++ b/ControlesAccesoQR/UserControls/TecladoNumerico.xaml
@@ -1,0 +1,26 @@
+<UserControl x:Class="ControlesAccesoQR.UserControls.TecladoNumerico"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Loaded="UserControl_Loaded">
+    <Grid>
+        <StackPanel>
+            <TextBox x:Name="InputTextBox"
+                     Text="{Binding Text, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+            <UniformGrid Rows="4" Columns="3" Margin="0,10,0,10">
+                <Button Content="1" Click="Numero_Click" Margin="2"/>
+                <Button Content="2" Click="Numero_Click" Margin="2"/>
+                <Button Content="3" Click="Numero_Click" Margin="2"/>
+                <Button Content="4" Click="Numero_Click" Margin="2"/>
+                <Button Content="5" Click="Numero_Click" Margin="2"/>
+                <Button Content="6" Click="Numero_Click" Margin="2"/>
+                <Button Content="7" Click="Numero_Click" Margin="2"/>
+                <Button Content="8" Click="Numero_Click" Margin="2"/>
+                <Button Content="9" Click="Numero_Click" Margin="2"/>
+                <Button Content="Limpiar" Click="Limpiar_Click" Margin="2"/>
+                <Button Content="0" Click="Numero_Click" Margin="2"/>
+                <Button Content="Borrar" Click="Borrar_Click" Margin="2"/>
+            </UniformGrid>
+            <Button Content="OK" Click="Ok_Click" Margin="0,0,0,10"/>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/ControlesAccesoQR/UserControls/TecladoNumerico.xaml.cs
+++ b/ControlesAccesoQR/UserControls/TecladoNumerico.xaml.cs
@@ -1,0 +1,67 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace ControlesAccesoQR.UserControls
+{
+    public partial class TecladoNumerico : UserControl
+    {
+        public TecladoNumerico()
+        {
+            InitializeComponent();
+        }
+
+        public static readonly DependencyProperty TextProperty =
+            DependencyProperty.Register(nameof(Text), typeof(string), typeof(TecladoNumerico),
+                new FrameworkPropertyMetadata(string.Empty, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault));
+
+        public string Text
+        {
+            get => (string)GetValue(TextProperty);
+            set => SetValue(TextProperty, value);
+        }
+
+        public static readonly DependencyProperty ComandoOkProperty =
+            DependencyProperty.Register(nameof(ComandoOk), typeof(ICommand), typeof(TecladoNumerico));
+
+        public ICommand ComandoOk
+        {
+            get => (ICommand)GetValue(ComandoOkProperty);
+            set => SetValue(ComandoOkProperty, value);
+        }
+
+        private void Numero_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button btn)
+            {
+                Text += btn.Content?.ToString();
+                InputTextBox.Focus();
+            }
+        }
+
+        private void Borrar_Click(object sender, RoutedEventArgs e)
+        {
+            if (!string.IsNullOrEmpty(Text))
+                Text = Text.Substring(0, Text.Length - 1);
+            InputTextBox.Focus();
+        }
+
+        private void Limpiar_Click(object sender, RoutedEventArgs e)
+        {
+            Text = string.Empty;
+            InputTextBox.Focus();
+        }
+
+        private void Ok_Click(object sender, RoutedEventArgs e)
+        {
+            if (ComandoOk?.CanExecute(null) == true)
+                ComandoOk.Execute(null);
+            InputTextBox.Focus();
+        }
+
+        private void UserControl_Loaded(object sender, RoutedEventArgs e)
+        {
+            InputTextBox.Focus();
+        }
+    }
+}

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
@@ -19,7 +19,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         private DateTime _horaLlegada;
         private bool _ingresoRealizado;
         private string _qrImagePath;
-        private string _numeroPase;
+        private string _codigoQR;
 
         private readonly PasePuertaDataAccess _dataAccess = new PasePuertaDataAccess();
         private readonly MainWindowViewModel _mainViewModel;
@@ -34,14 +34,13 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         public DateTime HoraLlegada { get => _horaLlegada; set { _horaLlegada = value; OnPropertyChanged(nameof(HoraLlegada)); } }
         public bool IngresoRealizado { get => _ingresoRealizado; set { _ingresoRealizado = value; OnPropertyChanged(nameof(IngresoRealizado)); } }
         public string QrImagePath { get => _qrImagePath; set { _qrImagePath = value; OnPropertyChanged(nameof(QrImagePath)); } }
-        public string NumeroPase
+        public string CodigoQR
         {
-            get => _numeroPase;
+            get => _codigoQR;
             set
             {
-                _numeroPase = value;
-                OnPropertyChanged(nameof(NumeroPase));
-                EscanearQr();
+                _codigoQR = value;
+                OnPropertyChanged(nameof(CodigoQR));
             }
         }
 
@@ -59,10 +58,10 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
 
         private void EscanearQr()
         {
-            if (string.IsNullOrWhiteSpace(NumeroPase))
+            if (string.IsNullOrWhiteSpace(CodigoQR))
                 return;
 
-            var datos = _dataAccess.ObtenerChoferEmpresaPorPase(NumeroPase);
+            var datos = _dataAccess.ObtenerChoferEmpresaPorPase(CodigoQR);
             if (datos != null)
             {
                 Nombre = datos.ChoferNombre;
@@ -74,16 +73,16 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
 
         private void Ingresar()
         {
-            if (string.IsNullOrWhiteSpace(NumeroPase))
+            if (string.IsNullOrWhiteSpace(CodigoQR))
                 return;
 
-            var resultado = _dataAccess.ActualizarFechaLlegada(NumeroPase);
+            var resultado = _dataAccess.ActualizarFechaLlegada(CodigoQR);
             if (resultado == null)
                 return;
 
             HoraLlegada = resultado.FechaHoraLlegada;
 
-            var qrText = $"{NumeroPase}|{resultado.FechaHoraLlegada:yyyy-MM-dd HH:mm:ss}";
+            var qrText = $"{CodigoQR}|{resultado.FechaHoraLlegada:yyyy-MM-dd HH:mm:ss}";
             using (var generator = new QRCodeGenerator())
             {
                 var data = generator.CreateQrCode(qrText, QRCodeGenerator.ECCLevel.Q);
@@ -103,7 +102,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
                 NombreChofer = Nombre,
                 Placa = Patente,
                 FechaHoraLlegada = HoraLlegada,
-                NumeroPase = NumeroPase,
+                NumeroPase = CodigoQR,
 
                 Estado = EstadoProcesoTipo.EnEspera
 

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:conv="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
+             xmlns:uc="clr-namespace:ControlesAccesoQR.UserControls"
              FontFamily="Microsoft Sans Serif">
     <UserControl.Resources>
         <conv:BooleanToVisibilityConverter x:Key="BoolToVis" />
@@ -20,8 +21,7 @@
     </UserControl.Resources>
     <Grid Background="{StaticResource StandardBackground}">
         <StackPanel Margin="20">
-            <Button Content="Escanear QR" Command="{Binding EscanearQrCommand}" Width="150" Margin="0,0,0,10" />
-            <TextBox x:Name="NumeroPaseTextBox" Text="{Binding NumeroPase, UpdateSourceTrigger=PropertyChanged}" Width="200" Margin="0,0,0,10" Loaded="NumeroPaseTextBox_Loaded" />
+            <uc:TecladoNumerico Text="{Binding CodigoQR, Mode=TwoWay}" ComandoOk="{Binding EscanearQrCommand}" Margin="0,0,0,10" />
             <TextBlock Text="{Binding Nombre, StringFormat=Nombre: {0}}" Margin="0,0,0,5" />
             <TextBlock Text="{Binding Empresa, StringFormat=Empresa: {0}}" Margin="0,0,0,5" />
            

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
@@ -39,9 +39,5 @@ namespace ControlesAccesoQR.Views.ControlesAccesoQR
             }
         }
 
-        private void NumeroPaseTextBox_Loaded(object sender, RoutedEventArgs e)
-        {
-            ((TextBox)sender).Focus();
-        }
     }
 }


### PR DESCRIPTION
## Summary
- create `TecladoNumerico` user control with digit buttons, delete, clear and OK; exposes bindable `Text` and `ComandoOk`
- add `CodigoQR` property to `VistaEntradaSalidaViewModel` and update QR scanning logic
- embed `TecladoNumerico` in `VistaEntradaSalida` view binding to `CodigoQR` and `EscanearQrCommand`

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` (command not found)
- `msbuild ControlesAccesoQR/ControlesAccesoQR.csproj` (command not found)
- `apt-get update` (403 Forbidden: repository not signed)


------
https://chatgpt.com/codex/tasks/task_e_688fc9948544833080d81e22b7c63ba0