### PR TITLE
Rediseñar interfaz de ingreso con teclado numerico

### DIFF
--- a/ControlesAccesoQR/UserControls/TecladoNumerico.xaml
+++ b/ControlesAccesoQR/UserControls/TecladoNumerico.xaml
@@ -2,25 +2,63 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              Loaded="UserControl_Loaded">
+    <UserControl.Resources>
+        <Style x:Key="NumericButtonStyle" TargetType="Button">
+            <Setter Property="Background" Value="#EF6C00" />
+            <Setter Property="Foreground" Value="White" />
+            <Setter Property="FontSize" Value="24" />
+            <Setter Property="Width" Value="80" />
+            <Setter Property="Height" Value="80" />
+            <Setter Property="Margin" Value="5" />
+        </Style>
+        <Style x:Key="OkButtonStyle" TargetType="Button" BasedOn="{StaticResource NumericButtonStyle}">
+            <Setter Property="Background" Value="#4CAF50" />
+            <Setter Property="FontWeight" Value="Bold" />
+            <Setter Property="Margin" Value="10,0,0,0" />
+            <Setter Property="Width" Value="100" />
+        </Style>
+        <Style x:Key="LimpiarButtonStyle" TargetType="Button" BasedOn="{StaticResource NumericButtonStyle}">
+            <Setter Property="Background" Value="#F44336" />
+        </Style>
+    </UserControl.Resources>
     <Grid>
-        <StackPanel>
-            <TextBox x:Name="InputTextBox"
-                     Text="{Binding Text, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
-            <UniformGrid Rows="4" Columns="3" Margin="0,10,0,10">
-                <Button Content="1" Click="Numero_Click" Margin="2"/>
-                <Button Content="2" Click="Numero_Click" Margin="2"/>
-                <Button Content="3" Click="Numero_Click" Margin="2"/>
-                <Button Content="4" Click="Numero_Click" Margin="2"/>
-                <Button Content="5" Click="Numero_Click" Margin="2"/>
-                <Button Content="6" Click="Numero_Click" Margin="2"/>
-                <Button Content="7" Click="Numero_Click" Margin="2"/>
-                <Button Content="8" Click="Numero_Click" Margin="2"/>
-                <Button Content="9" Click="Numero_Click" Margin="2"/>
-                <Button Content="Limpiar" Click="Limpiar_Click" Margin="2"/>
-                <Button Content="0" Click="Numero_Click" Margin="2"/>
-                <Button Content="Borrar" Click="Borrar_Click" Margin="2"/>
-            </UniformGrid>
-            <Button Content="OK" Click="Ok_Click" Margin="0,0,0,10"/>
-        </StackPanel>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
+        <TextBox x:Name="InputTextBox"
+                 Grid.ColumnSpan="2"
+                 Width="380"
+                 FontSize="32"
+                 Height="70"
+                 Margin="0,0,0,20"
+                 IsReadOnly="True"
+                 HorizontalContentAlignment="Center"
+                 Text="{Binding Text, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+        <UniformGrid x:Name="NumbersGrid" Grid.Row="1" Columns="3" Rows="4" Margin="0,0,10,0">
+            <Button Content="1" Style="{StaticResource NumericButtonStyle}" Click="Numero_Click" />
+            <Button Content="2" Style="{StaticResource NumericButtonStyle}" Click="Numero_Click" />
+            <Button Content="3" Style="{StaticResource NumericButtonStyle}" Click="Numero_Click" />
+            <Button Content="4" Style="{StaticResource NumericButtonStyle}" Click="Numero_Click" />
+            <Button Content="5" Style="{StaticResource NumericButtonStyle}" Click="Numero_Click" />
+            <Button Content="6" Style="{StaticResource NumericButtonStyle}" Click="Numero_Click" />
+            <Button Content="7" Style="{StaticResource NumericButtonStyle}" Click="Numero_Click" />
+            <Button Content="8" Style="{StaticResource NumericButtonStyle}" Click="Numero_Click" />
+            <Button Content="9" Style="{StaticResource NumericButtonStyle}" Click="Numero_Click" />
+            <Button Content="Limpiar" Style="{StaticResource LimpiarButtonStyle}" Click="Limpiar_Click" />
+            <Button Content="0" Style="{StaticResource NumericButtonStyle}" Click="Numero_Click" />
+            <Button Content="Borrar" Style="{StaticResource NumericButtonStyle}" Click="Borrar_Click" />
+        </UniformGrid>
+
+        <Button Grid.Row="1" Grid.Column="1" Content="OK"
+                Style="{StaticResource OkButtonStyle}"
+                Height="{Binding ElementName=NumbersGrid, Path=ActualHeight}"
+                Click="Ok_Click" />
     </Grid>
 </UserControl>

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
@@ -20,11 +20,20 @@
         </Style>
     </UserControl.Resources>
     <Grid Background="{StaticResource StandardBackground}">
-        <StackPanel Margin="20">
+        <StackPanel Margin="20" HorizontalAlignment="Center">
+            <TextBlock Text="INGRESO DE CÉDULA"
+                       FontSize="36"
+                       FontWeight="Bold"
+                       TextAlignment="Center"
+                       Margin="0,0,0,10" />
+            <TextBlock Text="Digite el número de cédula del conductor y luego presione el botón verde OK."
+                       TextWrapping="Wrap"
+                       TextAlignment="Center"
+                       Margin="0,0,0,20" />
             <uc:TecladoNumerico Text="{Binding CodigoQR, Mode=TwoWay}" ComandoOk="{Binding EscanearQrCommand}" Margin="0,0,0,10" />
             <TextBlock Text="{Binding Nombre, StringFormat=Nombre: {0}}" Margin="0,0,0,5" />
             <TextBlock Text="{Binding Empresa, StringFormat=Empresa: {0}}" Margin="0,0,0,5" />
-           
+
             <Button Content="Ingresar" Command="{Binding IngresarCommand}" Width="100" Margin="0,0,0,10" Click="IngresarButton_Click" />
             <StackPanel Visibility="{Binding IngresoRealizado, Converter={StaticResource BoolToVis}}">
                 <TextBlock Text="{Binding HoraLlegada, StringFormat=Hora de llegada: {0:HH\\:mm}}" Margin="0,0,0,5" />


### PR DESCRIPTION
## Summary
- Añadido título e instrucciones de uso en vista de entrada
- Rediseñado teclado numérico con área de display ampliada y botón OK lateral verde
- Estilizados botones numéricos naranja y opciones Limpiar/Borrar

## Testing
- `dotnet build` *(falló: command not found)*
- `apt-get update` *(falló: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688fee4248c48330a451c8e2bc4d6e3b