### PR TITLE
Cambiar cédula por número de pase en la vista de ingreso

### DIFF
--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
@@ -21,12 +21,12 @@
     </UserControl.Resources>
     <Grid Background="{StaticResource StandardBackground}">
         <StackPanel Margin="20" HorizontalAlignment="Center">
-            <TextBlock Text="INGRESO DE CÉDULA"
+            <TextBlock Text="INGRESO DE NÚMERO DE PASE"
                        FontSize="36"
                        FontWeight="Bold"
                        TextAlignment="Center"
                        Margin="0,0,0,10" />
-            <TextBlock Text="Digite el número de cédula del conductor y luego presione el botón verde OK."
+            <TextBlock Text="Digite el número de pase del conductor y luego presione el botón verde OK."
                        TextWrapping="Wrap"
                        TextAlignment="Center"
                        Margin="0,0,0,20" />


### PR DESCRIPTION
## Summary
- Ajustar etiquetas de la vista de ingreso para referirse al número de pase en lugar de la cédula.

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(falló: command not found: dotnet)*
- `apt-get update` *(falló: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688ff0522018833096969cde3f940a66