### PR TITLE
Add numeric keypad for exit pass entry

### DIFF
--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaSalidaFinalViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaSalidaFinalViewModel.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.ObjectModel;
 using System.Windows.Input;
 using ControlesAccesoQR.accesoDatos;
@@ -16,7 +15,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         private string _patente;
         private string _horaSalida;
         private bool _salidaRegistrada;
-        private string _qrLeido;
+        private string _numeroPaseSalida;
         private string _mensajeError;
         private readonly PasePuertaDataAccess _dataAccess = new PasePuertaDataAccess();
         private readonly MainWindowViewModel _mainViewModel;
@@ -26,59 +25,33 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         public string Patente { get => _patente; set { _patente = value; OnPropertyChanged(nameof(Patente)); } }
         public string HoraSalida { get => _horaSalida; set { _horaSalida = value; OnPropertyChanged(nameof(HoraSalida)); } }
         public bool SalidaRegistrada { get => _salidaRegistrada; set { _salidaRegistrada = value; OnPropertyChanged(nameof(SalidaRegistrada)); } }
-        public string QrLeido
-        {
-            get => _qrLeido;
-            set
-            {
-                _qrLeido = value;
-                OnPropertyChanged(nameof(QrLeido));
-                ProcesarQr();
-            }
-        }
+        public string NumeroPaseSalida { get => _numeroPaseSalida; set { _numeroPaseSalida = value; OnPropertyChanged(nameof(NumeroPaseSalida)); } }
         public string MensajeError { get => _mensajeError; set { _mensajeError = value; OnPropertyChanged(nameof(MensajeError)); } }
 
         public ObservableCollection<string> Contenedores { get; } = new ObservableCollection<string>();
 
-        public ICommand EscanearQrSalidaCommand { get; }
+        public ICommand ProcesarSalidaCommand { get; }
         public ICommand ImprimirSalidaCommand { get; }
 
         public VistaSalidaFinalViewModel(MainWindowViewModel mainViewModel)
         {
             _mainViewModel = mainViewModel;
-            EscanearQrSalidaCommand = new RelayCommand(EscanearQrSalida);
+            ProcesarSalidaCommand = new RelayCommand(ProcesarSalida);
             ImprimirSalidaCommand = new RelayCommand(ImprimirSalida);
 
             Contenedores.Add("CONT-001");
             Contenedores.Add("CONT-002");
         }
 
-        private void EscanearQrSalida()
-        {
-            // Simulación de escaneo
-            Nombre = "Transportista Demo";
-            Empresa = "Empresa Demo";
-            Patente = "ABC123";
-        }
-
-        private void ProcesarQr()
+        private void ProcesarSalida()
         {
             MensajeError = string.Empty;
             SalidaRegistrada = false;
 
-            if (string.IsNullOrWhiteSpace(QrLeido))
+            if (string.IsNullOrWhiteSpace(NumeroPaseSalida))
                 return;
 
-            if (!QrLeido.Contains("|"))
-            {
-                MensajeError = "Formato de QR inválido";
-                return;
-            }
-
-            var partes = QrLeido.Split('|');
-            var numeroPase = partes[0];
-
-            var resultado = _dataAccess.ActualizarFechaSalida(numeroPase);
+            var resultado = _dataAccess.ActualizarFechaSalida(NumeroPaseSalida);
             if (resultado != null)
             {
                 HoraSalida = resultado.FechaHoraSalida.ToString("HH:mm");
@@ -94,11 +67,15 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
                     FechaHoraSalida = resultado.FechaHoraSalida,
                     NumeroPase = resultado.NumeroPase,
 
-                    Estado = EstadoProcesoEnum.SalidaRegistrada
+                    Estado = EstadoProcesoEnum.SalidaRegistrada,
 
                 };
                 _mainViewModel.EstadoProceso = EstadoProcesoEnum.SalidaRegistrada;
                 _ = _mainViewModel.ReiniciarDespuesDeSalidaAsync();
+            }
+            else
+            {
+                MensajeError = "Número de pase inválido";
             }
         }
 
@@ -108,3 +85,4 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         }
     }
 }
+

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
@@ -2,6 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:conv="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
+             xmlns:uc="clr-namespace:ControlesAccesoQR.UserControls"
              FontFamily="Microsoft Sans Serif">
     <UserControl.Resources>
         <conv:BooleanToVisibilityConverter x:Key="BoolToVis" />
@@ -19,13 +20,23 @@
         </Style>
     </UserControl.Resources>
     <Grid Background="{StaticResource StandardBackground}">
-        <StackPanel Margin="20">
-            <Button Content="Escanear QR de Salida" Command="{Binding EscanearQrSalidaCommand}" Width="180" Margin="0,0,0,10" />
-            <TextBox Text="{Binding QrLeido, UpdateSourceTrigger=PropertyChanged}" Width="200" Margin="0,0,0,10" />
+        <StackPanel Margin="20" HorizontalAlignment="Center">
+            <TextBlock Text="INGRESO DE NÚMERO DE PASE DE SALIDA"
+                       FontSize="36"
+                       FontWeight="Bold"
+                       TextAlignment="Center"
+                       Margin="0,0,0,10" />
+            <TextBlock Text="Digite el número de pase del conductor y luego presione el botón verde OK."
+                       TextWrapping="Wrap"
+                       TextAlignment="Center"
+                       Margin="0,0,0,20" />
+            <uc:TecladoNumerico Text="{Binding NumeroPaseSalida, Mode=TwoWay}"
+                                ComandoOk="{Binding ProcesarSalidaCommand}"
+                                Margin="0,0,0,10" />
             <TextBlock Text="{Binding MensajeError}" Foreground="Red" Margin="0,0,0,5" />
             <TextBlock Text="{Binding Nombre, StringFormat=Nombre: {0}}" Margin="0,0,0,5" />
             <TextBlock Text="{Binding Empresa, StringFormat=Empresa: {0}}" Margin="0,0,0,5" />
-           
+
             <StackPanel Visibility="{Binding SalidaRegistrada, Converter={StaticResource BoolToVis}}">
                 <TextBlock Text="{Binding HoraSalida, StringFormat=Hora de salida: {0}}" Margin="0,0,0,5" />
                 <Button Content="Imprimir Salida" Command="{Binding ImprimirSalidaCommand}" Width="150" />


### PR DESCRIPTION
## Summary
- Embed numeric keypad layout on the exit pass screen with updated headings and instructions
- Bind keypad to new `NumeroPaseSalida` field and process exit via `ProcesarSalidaCommand`

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688ff998d32c8330b374cd5009013355