### PR TITLE
Add Common.Logging reference to ControlesAccesoQR

### DIFF
--- a/ControlesAccesoQR/ControlesAccesoQR.csproj
+++ b/ControlesAccesoQR/ControlesAccesoQR.csproj
@@ -54,6 +54,9 @@
     <Reference Include="Spring.Core">
       <HintPath>..\Recursos\Spring.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Common.Logging">
+      <HintPath>..\Recursos\Common.Logging.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
## Summary
- add Common.Logging assembly reference in ControlesAccesoQR project

## Testing
- `msbuild ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890feebe17c8330ac2408b085d38731