### PR TITLE
Use Transaction antenna configuration in ControlesAccesoQR

### DIFF
--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/PaginaRfidViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/PaginaRfidViewModel.cs
@@ -1,6 +1,7 @@
 using ControlesAccesoQR.accesoDatos;
 using RECEPTIO.CapaPresentacion.UI.Interfaces.RFID;
 using Spring.Context.Support;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -31,8 +32,15 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
             _placa = placa;
             Titulo = "LECTURA RFID";
             EsVisibleBoton = Visibility.Collapsed;
-            var ctx = new XmlApplicationContext("~/Springs/SpringAntena.xml");
-            _antena = (IAntena)ctx["AdministradorAntena"];
+            try
+            {
+                var ctx = new XmlApplicationContext(@"..\..\..\Transaction\Springs\SpringAntena.xml");
+                _antena = (IAntena)ctx["AdministradorAntena"];
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Error al cargar configuración desde Transaction: " + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Load antenna settings from the Transaction project's SpringAntena.xml
- Handle failures gracefully when loading antenna configuration
- Add missing System namespace for new exception handling

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689110e0edfc83308ee9bcb9039e0815