### PR TITLE
Consume kiosk service in ControlesAccesoQR

### DIFF
--- a/ControlesAccesoQR/App.config
+++ b/ControlesAccesoQR/App.config
@@ -6,5 +6,22 @@
   </connectionStrings>
   <appSettings>
     <add key="PuertoRFID" value="2" />
+    <add key="IP_LOCAL" value="127.0.0.1" />
   </appSettings>
+  <system.serviceModel>
+    <bindings>
+      <wsHttpBinding>
+        <binding name="WSHttpBinding_IServicioTransaction" maxBufferPoolSize="2147483647" maxReceivedMessageSize="2147483647" messageEncoding="Mtom">
+          <security mode="None" />
+        </binding>
+      </wsHttpBinding>
+    </bindings>
+    <client>
+      <endpoint address="http://192.168.0.84:50502/WS_RECEPTIOTransaction/ServicioTransaction.svc"
+                binding="wsHttpBinding"
+                bindingConfiguration="WSHttpBinding_IServicioTransaction"
+                contract="ServicioTransaction.IServicioTransaction"
+                name="WSHttpBinding_IServicioTransaction" />
+    </client>
+  </system.serviceModel>
 </configuration>

--- a/ControlesAccesoQR/ControlesAccesoQR.csproj
+++ b/ControlesAccesoQR/ControlesAccesoQR.csproj
@@ -60,6 +60,8 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Data" />
     <Reference Include="System.Configuration" />
@@ -106,6 +108,9 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Compile Include="..\Transaction\Connected Services\ServicioTransaction\Reference.cs">
+      <Link>Connected Services\ServicioTransaction\Reference.cs</Link>
+    </Compile>
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>

--- a/ControlesAccesoQR/MainWindow.xaml
+++ b/ControlesAccesoQR/MainWindow.xaml
@@ -25,6 +25,7 @@
         </Grid.ColumnDefinitions>
         <DockPanel Grid.Column="0">
             <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="10">
+                <TextBlock Text="{Binding NumeroKiosco}" FontSize="20" Margin="0,0,20,0" VerticalAlignment="Center" />
                 <Button Content="Entrada" Command="{Binding MostrarEntradaSalidaCommand}" Margin="0,0,10,0" />
                 <Button Content="Salida Final" Command="{Binding MostrarSalidaFinalCommand}" />
             </StackPanel>


### PR DESCRIPTION
## Summary
- Load kiosk information on startup using `ServicioComunKioscoClient` and show its number in the main view.
- Configure WCF endpoint and local IP settings for kiosk lookup.
- Link existing service proxy and required WCF assemblies.

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden repositories)*

------
https://chatgpt.com/codex/tasks/task_e_689227c98160833093093b6df4c73b59