### PR TITLE
Agregar panel lateral de estados en ControlesAccesoQR

### DIFF
--- a/ControlesAccesoQR/ControlesAccesoQR.csproj
+++ b/ControlesAccesoQR/ControlesAccesoQR.csproj
@@ -133,6 +133,8 @@
     <Compile Include="ViewModels\ControlesAccesoQR\EstadoProceso.Estaticos.cs" />
     <Compile Include="ViewModels\ControlesAccesoQR\PaginaRfidViewModel.cs" />
     <Compile Include="ViewModels\ControlesAccesoQR\HuellaViewModel.cs" />
+    <Compile Include="Estados\EstadoProceso.cs" />
+    <Compile Include="Converters\EqualityConverter.cs" />
     <Compile Include="Views\ControlesAccesoQR\VistaEntradaSalida.xaml.cs">
       <DependentUpon>VistaEntradaSalida.xaml</DependentUpon>
     </Compile>

--- a/ControlesAccesoQR/Converters/EqualityConverter.cs
+++ b/ControlesAccesoQR/Converters/EqualityConverter.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace ControlesAccesoQR.Converters
+{
+    public class EqualityConverter : IMultiValueConverter
+    {
+        public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (values == null || values.Length < 2)
+                return false;
+            return Equals(values[0], values[1]);
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+    }
+}

--- a/ControlesAccesoQR/Estados/EstadoProceso.cs
+++ b/ControlesAccesoQR/Estados/EstadoProceso.cs
@@ -1,0 +1,11 @@
+namespace ControlesAccesoQR.Estados
+{
+    public enum EstadoProceso
+    {
+        Huella,
+        Tag,
+        Procesos,
+        Ticket,
+        Barrera
+    }
+}

--- a/ControlesAccesoQR/MainWindow.xaml
+++ b/ControlesAccesoQR/MainWindow.xaml
@@ -1,7 +1,8 @@
 <Window x:Class="ControlesAccesoQR.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:views="clr-namespace:ControlesAccesoQR.Views.ControlesAccesoQR"
+        xmlns:estados="clr-namespace:ControlesAccesoQR.Estados"
+        xmlns:conv="clr-namespace:ControlesAccesoQR.Converters"
         Title="ControlesAccesoQR"
         Height="450"
         Width="800"
@@ -17,6 +18,7 @@
             <Setter Property="Foreground" Value="White" />
             <Setter Property="FontSize" Value="20" />
         </Style>
+        <conv:EqualityConverter x:Key="EqualityConverter" />
     </Window.Resources>
     <Grid Background="{StaticResource StandardBackground}">
         <Grid.ColumnDefinitions>
@@ -31,6 +33,78 @@
             </StackPanel>
             <Frame x:Name="MainFrame" NavigationUIVisibility="Hidden" />
         </DockPanel>
-        <views:EstadoProcesoPanel Grid.Column="1" />
+        <Border Grid.Column="1" BorderBrush="#E65100" BorderThickness="5">
+            <DockPanel>
+                <StackPanel DockPanel.Dock="Top">
+                    <StackPanel Orientation="Horizontal" Height="70" Background="#EF6C00" HorizontalAlignment="Left" Width="350">
+                        <TextBlock Text="Datos" FontSize="36" Foreground="White" VerticalAlignment="Center" Margin="20,0,0,0"/>
+                    </StackPanel>
+                    <ItemsControl ItemsSource="{Binding Estados}" Width="350">
+                        <ItemsControl.ItemContainerStyle>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="Background" Value="#E0E0E0"/>
+                                <Setter Property="Margin" Value="0,0,0,5"/>
+                                <Setter Property="TextElement.Foreground" Value="#191007"/>
+                                <Style.Triggers>
+                                    <DataTrigger Value="True">
+                                        <DataTrigger.Binding>
+                                            <MultiBinding Converter="{StaticResource EqualityConverter}">
+                                                <Binding/>
+                                                <Binding Path="EstadoActual" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                                            </MultiBinding>
+                                        </DataTrigger.Binding>
+                                        <Setter Property="Background" Value="#EF6C00"/>
+                                        <Setter Property="TextElement.Foreground" Value="White"/>
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ItemsControl.ItemContainerStyle>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Grid Height="70" Width="350" Background="{Binding RelativeSource={RelativeSource AncestorType=ContentPresenter}, Path=Background}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="80"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" FontSize="36" VerticalAlignment="Center" HorizontalAlignment="Center">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Setter Property="Text" Value=""/>
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding}" Value="{x:Static estados:EstadoProceso.Huella}">
+                                                        <Setter Property="Text" Value="🖐"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding}" Value="{x:Static estados:EstadoProceso.Tag}">
+                                                        <Setter Property="Text" Value="🏷"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding}" Value="{x:Static estados:EstadoProceso.Procesos}">
+                                                        <Setter Property="Text" Value="⚙"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding}" Value="{x:Static estados:EstadoProceso.Ticket}">
+                                                        <Setter Property="Text" Value="🎫"/>
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding}" Value="{x:Static estados:EstadoProceso.Barrera}">
+                                                        <Setter Property="Text" Value="🚧"/>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                    <TextBlock Grid.Column="1" Text="{Binding}" FontSize="36" VerticalAlignment="Center" Margin="20,0,0,0"/>
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+                <StackPanel DockPanel.Dock="Bottom" Margin="0,10" HorizontalAlignment="Center" Width="350">
+                    <TextBlock Text="Kiosco" FontSize="40" Foreground="#191007" TextAlignment="Center" />
+                    <TextBlock Text="{Binding NumeroKiosco}" FontSize="120" Foreground="White" Background="#EF6C00" TextAlignment="Center" Margin="0,0,0,10"/>
+                    <TextBlock Text="{Binding FechaHora}" FontSize="24" Foreground="#191007" TextAlignment="Center" />
+                    <Border Height="100" Background="Gray" Margin="0,10,0,0">
+                        <TextBlock Text="Logo" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
+                    </Border>
+                </StackPanel>
+            </DockPanel>
+        </Border>
     </Grid>
 </Window>

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Configuration;
 using System.Linq;
@@ -6,9 +8,11 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Threading;
 using ControlesAccesoQR.Models;
 using ControlesAccesoQR.Views.ControlesAccesoQR;
 
+using EstadoPanel = ControlesAccesoQR.Estados.EstadoProceso;
 using EstadoProcesoEnum = ControlesAccesoQR.Models.EstadoProceso;
 
 using RECEPTIO.CapaPresentacion.UI.MVVM;
@@ -25,8 +29,13 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         private EstadoProcesoEnum _ultimoEstadoVisible = EstadoProcesoEnum.EnEspera;
         private PaseProcesoModel _paseActual;
         private string _numeroKiosco;
+        private EstadoPanel _estadoActual = EstadoPanel.Huella;
+        private string _fechaHora = DateTime.Now.ToString("dd/MM/yyyy HH:mm");
+        private readonly DispatcherTimer _reloj = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
 
         public ObservableCollection<Proceso> Procesos { get; } = new ObservableCollection<Proceso>();
+
+        public IEnumerable<EstadoPanel> Estados { get; } = Enum.GetValues(typeof(EstadoPanel)).Cast<EstadoPanel>();
 
         public ICommand MostrarEntradaSalidaCommand { get; }
         public ICommand MostrarSalidaFinalCommand { get; }
@@ -35,6 +44,18 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         {
             get => _numeroKiosco;
             private set { _numeroKiosco = value; OnPropertyChanged(nameof(NumeroKiosco)); }
+        }
+
+        public EstadoPanel EstadoActual
+        {
+            get => _estadoActual;
+            set { _estadoActual = value; OnPropertyChanged(nameof(EstadoActual)); }
+        }
+
+        public string FechaHora
+        {
+            get => _fechaHora;
+            private set { _fechaHora = value; OnPropertyChanged(nameof(FechaHora)); }
         }
 
         public EstadoProcesoEnum EstadoProceso
@@ -66,6 +87,9 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
             _frame = frame;
             MostrarEntradaSalidaCommand = new RelayCommand(MostrarEntradaSalida);
             MostrarSalidaFinalCommand = new RelayCommand(MostrarSalidaFinal);
+
+            _reloj.Tick += (s, e) => FechaHora = DateTime.Now.ToString("dd/MM/yyyy HH:mm");
+            _reloj.Start();
 
             ObtenerQuiosco();
         }


### PR DESCRIPTION
## Summary
- Añadido enum `EstadoProceso` para definir los estados Huella, Tag, Procesos, Ticket y Barrera.
- El `MainWindowViewModel` ahora expone colección de estados, estado actual y reloj para la UI.
- Rediseñada `MainWindow.xaml` con panel lateral que muestra los estados con iconos y datos del kiosco.

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(falló: command not found: dotnet)*
- `apt-get update` *(falló: 403 Forbidden repositories)*

------
https://chatgpt.com/codex/tasks/task_e_6892689840648330b200a4d825be5409