### PR TITLE
feat: display institutional logo in ControlesAccesoQR

### DIFF
--- a/ControlesAccesoQR/MainWindow.xaml
+++ b/ControlesAccesoQR/MainWindow.xaml
@@ -113,9 +113,12 @@
                     <TextBlock Text="Kiosco" FontSize="40" Foreground="#191007" TextAlignment="Center" />
                     <TextBlock Text="{Binding NumeroKiosco}" FontSize="120" Foreground="White" Background="#EF6C00" TextAlignment="Center" Margin="0,0,0,10"/>
                     <TextBlock Text="{Binding FechaHora}" FontSize="24" Foreground="#191007" TextAlignment="Center" />
-                    <Border Height="100" Background="Gray" Margin="0,10,0,0">
-                        <TextBlock Text="Logo" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
-                    </Border>
+                    <Image Source="Assets/logo_contecon.png"
+                           Height="100"
+                           Stretch="Uniform"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center"
+                           Margin="0,10,0,0"/>
                 </StackPanel>
             </DockPanel>
         </Border>


### PR DESCRIPTION
## Summary
- show institutional logo below clock in ControlesAccesoQR sidebar

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: dotnet command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689270a8416c83308bcb8fe76535d375