### PR TITLE
Agregar ventana de prueba RFID

### DIFF
--- a/ControlesAccesoQR/ControlesAccesoQR.csproj
+++ b/ControlesAccesoQR/ControlesAccesoQR.csproj
@@ -84,6 +84,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="RFIDTestWindow.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="UserControls\TecladoNumerico.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -116,6 +120,9 @@
     </Compile>
     <Compile Include="MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="RFIDTestWindow.xaml.cs">
+      <DependentUpon>RFIDTestWindow.xaml</DependentUpon>
     </Compile>
     <Compile Include="UserControls\TecladoNumerico.xaml.cs">
       <DependentUpon>TecladoNumerico.xaml</DependentUpon>

--- a/ControlesAccesoQR/MainWindow.xaml
+++ b/ControlesAccesoQR/MainWindow.xaml
@@ -33,6 +33,7 @@
                 <TextBlock Text="{Binding NumeroKiosco}" FontSize="20" Margin="0,0,20,0" VerticalAlignment="Center" />
                 <Button Content="Entrada" Command="{Binding MostrarEntradaSalidaCommand}" Margin="0,0,10,0" />
                 <Button Content="Salida Final" Command="{Binding MostrarSalidaFinalCommand}" />
+                <Button Content="Abrir pantalla de test RFID" Click="AbrirRfIdTest_Click" Margin="10,0,0,0" />
             </StackPanel>
             <Frame x:Name="MainFrame" NavigationUIVisibility="Hidden" />
         </DockPanel>

--- a/ControlesAccesoQR/MainWindow.xaml.cs
+++ b/ControlesAccesoQR/MainWindow.xaml.cs
@@ -10,5 +10,11 @@ namespace ControlesAccesoQR
             InitializeComponent();
             DataContext = new MainWindowViewModel(MainFrame);
         }
+
+        private void AbrirRfIdTest_Click(object sender, RoutedEventArgs e)
+        {
+            var ventana = new RFIDTestWindow();
+            ventana.Show();
+        }
     }
 }

--- a/ControlesAccesoQR/RFIDTestWindow.xaml
+++ b/ControlesAccesoQR/RFIDTestWindow.xaml
@@ -1,0 +1,9 @@
+<Window x:Class="ControlesAccesoQR.RFIDTestWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="RFID Test" Height="300" Width="400" WindowStartupLocation="CenterScreen"
+        Loaded="Window_Loaded" Closed="Window_Closed">
+    <Grid>
+        <ListView x:Name="TagsListView"/>
+    </Grid>
+</Window>

--- a/ControlesAccesoQR/RFIDTestWindow.xaml.cs
+++ b/ControlesAccesoQR/RFIDTestWindow.xaml.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Threading;
+using RECEPTIO.CapaPresentacion.UI.Interfaces.RFID;
+using Spring.Context.Support;
+
+namespace ControlesAccesoQR
+{
+    public partial class RFIDTestWindow : Window
+    {
+        private IAntena _antena;
+        private DispatcherTimer _timer;
+        private ObservableCollection<string> _tags = new ObservableCollection<string>();
+
+        public RFIDTestWindow()
+        {
+            InitializeComponent();
+            TagsListView.ItemsSource = _tags;
+        }
+
+        private void Window_Loaded(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var ctx = new XmlApplicationContext("~/Springs/SpringAntena.xml");
+                _antena = (IAntena)ctx["AdministradorAntena"];
+                if (!_antena.ConectarAntena())
+                {
+                    MessageBox.Show("No se pudo conectar a la antena RFID");
+                    Close();
+                    return;
+                }
+                _antena.IniciarLectura();
+                _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+                _timer.Tick += (s, args) =>
+                {
+                    try
+                    {
+                        var tags = _antena.ObtenerTagsLeidos();
+                        foreach (var tag in tags)
+                        {
+                            if (!_tags.Contains(tag))
+                                _tags.Add(tag);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        MessageBox.Show(ex.Message);
+                    }
+                };
+                _timer.Start();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message);
+            }
+        }
+
+        private void Window_Closed(object sender, EventArgs e)
+        {
+            try
+            {
+                _timer?.Stop();
+                _antena?.TerminarLectura();
+                _antena?.DesconectarAntena();
+                _antena?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Añadir botón en la ventana principal para abrir pruebas de RFID
- Implementar ventana independiente `RFIDTestWindow` que realiza lectura continua de tags y los muestra en una lista
- Registrar nuevos archivos en el proyecto

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(falló: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_6896081d911c8330896fe85c87c7c107