### PR TITLE
Reorder QR control menu and remove unused items

### DIFF
--- a/ControlesAccesoQR/Estados/EstadoProceso.cs
+++ b/ControlesAccesoQR/Estados/EstadoProceso.cs
@@ -2,10 +2,9 @@ namespace ControlesAccesoQR.Estados
 {
     public enum EstadoProceso
     {
+        Pase,
         Huella,
         Tag,
-        Procesos,
-        Ticket,
-        Barrera
+        Ticket
     }
 }

--- a/ControlesAccesoQR/MainWindow.xaml
+++ b/ControlesAccesoQR/MainWindow.xaml
@@ -89,14 +89,11 @@
                                                     <DataTrigger Binding="{Binding}" Value="{x:Static estados:EstadoProceso.Tag}">
                                                         <Setter Property="Text" Value="🏷"/>
                                                     </DataTrigger>
-                                                    <DataTrigger Binding="{Binding}" Value="{x:Static estados:EstadoProceso.Procesos}">
+                                                    <DataTrigger Binding="{Binding}" Value="{x:Static estados:EstadoProceso.Pase}">
                                                         <Setter Property="Text" Value="🔢"/>
                                                     </DataTrigger>
                                                     <DataTrigger Binding="{Binding}" Value="{x:Static estados:EstadoProceso.Ticket}">
                                                         <Setter Property="Text" Value="🎫"/>
-                                                    </DataTrigger>
-                                                    <DataTrigger Binding="{Binding}" Value="{x:Static estados:EstadoProceso.Barrera}">
-                                                        <Setter Property="Text" Value="🚧"/>
                                                     </DataTrigger>
                                                 </Style.Triggers>
                                             </Style>
@@ -106,11 +103,6 @@
                                         <TextBlock.Style>
                                             <Style TargetType="TextBlock">
                                                 <Setter Property="Text" Value="{Binding}"/>
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding}" Value="{x:Static estados:EstadoProceso.Procesos}">
-                                                        <Setter Property="Text" Value="Ingresar número de pase"/>
-                                                    </DataTrigger>
-                                                </Style.Triggers>
                                             </Style>
                                         </TextBlock.Style>
                                     </TextBlock>
@@ -118,16 +110,6 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                </StackPanel>
-
-                <!-- Panel inferior -->
-                <StackPanel DockPanel.Dock="Bottom" Margin="0,10" HorizontalAlignment="Center" Width="350">
-                    <TextBlock Text="Kiosco" FontSize="40" Foreground="#191007" TextAlignment="Center" />
-                    <TextBlock Text="{Binding NumeroKiosco}" FontSize="120" Foreground="White" Background="#EF6C00" TextAlignment="Center" Margin="0,0,0,10"/>
-                    <TextBlock Text="{Binding FechaHora}" FontSize="24" Foreground="#191007" TextAlignment="Center" />
-                    <Border Height="100" Background="Gray" Margin="0,10,0,0">
-                        <TextBlock Text="Logo" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="White"/>
-                    </Border>
                 </StackPanel>
             </DockPanel>
         </Border>


### PR DESCRIPTION
## Summary
- Rename and reorder menu enumeration to show Pase first
- Simplify MainWindow XAML by replacing "Procesos" with "Pase" and drop Barrera/Kiosco items

## Testing
- `apt-get update` *(fails: repository not signed)*
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68993121d4a88330b395141159e0d1a2