### PR TITLE
feat: add async estado update service

### DIFF
--- a/ControlesAccesoQR/ControlesAccesoQR.csproj
+++ b/ControlesAccesoQR/ControlesAccesoQR.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Models\EstadoProceso.cs" />
     <Compile Include="Models\PaseProcesoModel.cs" />
     <Compile Include="Models\Proceso.cs" />
+    <Compile Include="Models\ActualizarEstadoResult.cs" />
     <Compile Include="ViewModels\ControlesAccesoQR\EstadoProceso.cs" />
     <Compile Include="ViewModels\ControlesAccesoQR\EstadoEnEspera.cs" />
     <Compile Include="ViewModels\ControlesAccesoQR\EstadoIngresoRegistrado.cs" />
@@ -161,6 +162,8 @@
     </Compile>
     <Compile Include="Impresion\ImprimirTicketQr.cs" />
     <Compile Include="accesoDatos\PasePuertaDataAccess.cs" />
+    <Compile Include="Servicios\IEstadoService.cs" />
+    <Compile Include="Servicios\EstadoService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ControlesAccesoQR/Models/ActualizarEstadoResult.cs
+++ b/ControlesAccesoQR/Models/ActualizarEstadoResult.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace ControlesAccesoQR.Models
+{
+    public class ActualizarEstadoResult
+    {
+        public int PasePuertaID { get; set; }
+        public string NumeroPase { get; set; }
+        public string Estado { get; set; }
+        public DateTime FechaCreacion { get; set; }
+        public DateTime? FechaActualizacion { get; set; }
+    }
+}

--- a/ControlesAccesoQR/Servicios/EstadoService.cs
+++ b/ControlesAccesoQR/Servicios/EstadoService.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ControlesAccesoQR.accesoDatos;
+using ControlesAccesoQR.Models;
+
+namespace ControlesAccesoQR.Servicios
+{
+    public class EstadoService : IEstadoService
+    {
+        private readonly PasePuertaDataAccess _dataAccess;
+
+        public EstadoService()
+        {
+            _dataAccess = new PasePuertaDataAccess();
+        }
+
+        public Task<ActualizarEstadoResult> ActualizarAsync(string numeroPase, string estado, CancellationToken ct = default)
+        {
+            return _dataAccess.ActualizarEstadoAsync(numeroPase, estado, ct);
+        }
+    }
+}

--- a/ControlesAccesoQR/Servicios/IEstadoService.cs
+++ b/ControlesAccesoQR/Servicios/IEstadoService.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ControlesAccesoQR.Models;
+
+namespace ControlesAccesoQR.Servicios
+{
+    public interface IEstadoService
+    {
+        Task<ActualizarEstadoResult> ActualizarAsync(string numeroPase, string estado, CancellationToken ct = default);
+    }
+}

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
@@ -28,11 +28,11 @@ namespace ControlesAccesoQR.Views.ControlesAccesoQR
                     {
                         await CompletarValidacionHuellaAsync(vm, "BYPASS CGDE041", 1);
                         MessageBox.Show("Huella validada");
-                        vm.ActualizarEstado("H");
+                        await vm.ActualizarEstadoAsync("H");
 
                         await CompletarLecturaRfidAsync(vm, "TAG_SIMULADO");
                         MessageBox.Show("RFID detectado");
-                        vm.ActualizarEstado("R");
+                        await vm.ActualizarEstadoAsync("R");
                         return;
                     }
 
@@ -43,9 +43,9 @@ namespace ControlesAccesoQR.Views.ControlesAccesoQR
 
                         if (hv.HuellaValida)
                         {
-                            vm.ActualizarEstado("H");
+                            await vm.ActualizarEstadoAsync("H");
                             await CompletarLecturaRfidAsync(vm, null);
-                            vm.ActualizarEstado("R");
+                            await vm.ActualizarEstadoAsync("R");
                         }
                     }
                 }
@@ -60,12 +60,12 @@ namespace ControlesAccesoQR.Views.ControlesAccesoQR
                 {
                     await CompletarImpresionAsync(vm);
                     MessageBox.Show("Impresión simulada (CGDE041)");
-                    vm.ActualizarEstado("P");
+                    await vm.ActualizarEstadoAsync("P");
                     return;
                 }
 
                 await CompletarImpresionAsync(vm);
-                vm.ActualizarEstado("P");
+                await vm.ActualizarEstadoAsync("P");
                 LimpiarFormularioPostProceso();
             }
         }


### PR DESCRIPTION
## Summary
- add async `ActualizarEstadoAsync` in `PasePuertaDataAccess`
- introduce `IEstadoService` and `EstadoService` wrappers
- update view models and views to use async state updates and refresh UI

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `msbuild ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899372737148330b94ff2cf4f73315b