### PR TITLE
Propagate panel state changes using event

### DIFF
--- a/ControlesAccesoQR/ControlesAccesoQR.csproj
+++ b/ControlesAccesoQR/ControlesAccesoQR.csproj
@@ -165,6 +165,7 @@
     <Compile Include="accesoDatos\PasePuertaDataAccess.cs" />
     <Compile Include="Servicios\IEstadoService.cs" />
     <Compile Include="Servicios\EstadoService.cs" />
+    <Compile Include="Servicios\EstadoPanelEvents.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ControlesAccesoQR/MainWindow.xaml
+++ b/ControlesAccesoQR/MainWindow.xaml
@@ -56,7 +56,7 @@
                                         <DataTrigger.Binding>
                                             <MultiBinding Converter="{StaticResource EqualityConverter}">
                                                 <Binding/>
-                                                <Binding Path="EstadoProcesoActual" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                                                <Binding Path="EstadoPanelActual" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
                                             </MultiBinding>
                                         </DataTrigger.Binding>
                                         <Setter Property="TextElement.Foreground" Value="White"/>
@@ -71,7 +71,7 @@
                                     <Grid.Background>
                                         <MultiBinding Converter="{StaticResource EqualityConverter}">
                                             <Binding/>
-                                            <Binding Path="EstadoProcesoActual" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
+                                            <Binding Path="EstadoPanelActual" RelativeSource="{RelativeSource AncestorType=ItemsControl}"/>
                                         </MultiBinding>
                                     </Grid.Background>
                                     <Grid.ColumnDefinitions>

--- a/ControlesAccesoQR/Servicios/EstadoPanelEvents.cs
+++ b/ControlesAccesoQR/Servicios/EstadoPanelEvents.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace ControlesAccesoQR.Servicios
+{
+    public static class EstadoPanelEvents
+    {
+        public static event Action<string> EstadoCodigoCambiado;
+
+        public static void RaiseEstadoCodigoCambiado(string codigo)
+        {
+            var handler = EstadoCodigoCambiado;
+            if (handler != null) handler(codigo);
+        }
+    }
+}

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
@@ -194,7 +194,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
                 EstadoActual = result.Estado;
                 CodigoQR = result.PasePuertaID.ToString();
                 UltimaActualizacion = result.FechaActualizacion;
-                _mainViewModel.EstadoProcesoActual = _mainViewModel.MapEstadoToProceso(result.Estado);
+                EstadoPanelEvents.RaiseEstadoCodigoCambiado(result.Estado);
                 return true;
             }
             catch (SqlException ex)


### PR DESCRIPTION
## Summary
- Notify panel state changes via new `EstadoPanelEvents`.
- Add `EstadoPanelActual` bindable property and thread-safe update method in `MainWindowViewModel`.
- Raise state change events from `VistaEntradaSalidaViewModel` and bind UI to `EstadoPanelActual`.

## Testing
- `dotnet build ControlesAccesoQR.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68994d558ab0833080e1ce935d68b76a