### PR TITLE
Fix header spacing and center numeric keypad

### DIFF
--- a/ControlesAccesoQR/MainWindow.xaml
+++ b/ControlesAccesoQR/MainWindow.xaml
@@ -40,14 +40,35 @@
         </DockPanel>
 
         <!-- Panel derecho de estados -->
-        <Border Grid.Column="1" BorderBrush="#E65100" BorderThickness="5">
-            <DockPanel>
-                <StackPanel DockPanel.Dock="Top">
-                    <StackPanel Orientation="Horizontal" Height="70" Background="#EF6C00" HorizontalAlignment="Left" Width="350">
-                        <TextBlock Text="Datos" FontSize="36" Foreground="White" VerticalAlignment="Center" Margin="20,0,0,0"/>
-                    </StackPanel>
+        <Border Grid.Column="1"
+                BorderBrush="#E65100"
+                BorderThickness="5"
+                CornerRadius="8"
+                Background="White"
+                SnapsToDevicePixels="True">
+            <Grid ClipToBounds="True">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="*" />
+                </Grid.RowDefinitions>
 
-                    <ItemsControl ItemsSource="{Binding Estados}" Width="350">
+                <Border Background="#EF6C00"
+                        CornerRadius="8,8,0,0"
+                        Height="70"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Top"
+                        SnapsToDevicePixels="True"
+                        ClipToBounds="True"
+                        Panel.ZIndex="1">
+                    <TextBlock Text="Datos"
+                               FontSize="36"
+                               Foreground="White"
+                               VerticalAlignment="Center"
+                               Margin="20,0,0,0" />
+                </Border>
+
+                <ScrollViewer Grid.Row="1" Margin="0">
+                    <ItemsControl ItemsSource="{Binding Estados}">
                         <ItemsControl.ItemContainerStyle>
                             <Style TargetType="ContentPresenter">
                                 <Setter Property="Margin" Value="0,0,0,5"/>
@@ -113,8 +134,8 @@
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                </StackPanel>
-            </DockPanel>
+                </ScrollViewer>
+            </Grid>
         </Border>
     </Grid>
 </Window>

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
@@ -36,7 +36,25 @@
                            TextWrapping="Wrap"
                            TextAlignment="Center"
                            Margin="0,0,0,20" />
-                <uc:TecladoNumerico Text="{Binding CodigoQR, Mode=TwoWay}" ComandoOk="{Binding EscanearQrCommand}" Margin="0,0,0,10" />
+                <Grid HorizontalAlignment="Center" Margin="0,0,0,10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="20"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <uc:TecladoNumerico x:Name="Teclado"
+                                        Grid.Column="0"
+                                        Text="{Binding CodigoQR, Mode=TwoWay}"
+                                        ComandoOk="{Binding EscanearQrCommand}"/>
+
+                    <Button Grid.Column="2"
+                            Content="OK"
+                            Width="140"
+                            Height="{Binding ElementName=Teclado, Path=ActualHeight, FallbackValue=300}"
+                            VerticalAlignment="Stretch"
+                            Command="{Binding EscanearQrCommand}"/>
+                </Grid>
                 <TextBlock Text="{Binding Nombre, StringFormat=Nombre: {0}}" Margin="0,0,0,5" />
                 <TextBlock Text="{Binding Empresa, StringFormat=Empresa: {0}}" Margin="0,0,0,5" />
 


### PR DESCRIPTION
## Summary
- Ensure right-side "Datos" panel header fills rounded corners without gaps
- Center numeric keypad and align external OK button

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a3aee546083309f9acca6a1458ff4