### PR TITLE
Fix TecladoNumerico namespace usage

### DIFF
--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:conv="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
-             xmlns:uc="clr-namespace:ControlesAccesoQR.UserControls"
+             xmlns:uc="clr-namespace:ControlesAccesoQR.UserControls;assembly=ControlesAccesoQR"
              FontFamily="Microsoft Sans Serif">
     <UserControl.Resources>
         <conv:BooleanToVisibilityConverter x:Key="BoolToVis" />

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
@@ -2,7 +2,7 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:conv="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
-             xmlns:uc="clr-namespace:ControlesAccesoQR.UserControls"
+             xmlns:uc="clr-namespace:ControlesAccesoQR.UserControls;assembly=ControlesAccesoQR"
              FontFamily="Microsoft Sans Serif">
     <UserControl.Resources>
         <conv:BooleanToVisibilityConverter x:Key="BoolToVis" />


### PR DESCRIPTION
## Summary
- reference TecladoNumerico from ControlesAccesoQR.UserControls in VistaEntradaSalida
- reference TecladoNumerico from ControlesAccesoQR.UserControls in VistaSalidaFinal

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689a3e2c9e408330af0615e7b3d079d0