### PR TITLE
UI: centrar TecladoNumerico sin afectar panel Datos; corregir xmlns del control y

### DIFF
--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
@@ -20,13 +20,19 @@
         </Style>
     </UserControl.Resources>
     <Grid Background="{StaticResource StandardBackground}">
-        <ScrollViewer VerticalScrollBarVisibility="Auto"
-                      HorizontalScrollBarVisibility="Disabled"
-                      CanContentScroll="True"
-                      PanningMode="VerticalOnly">
-            <StackPanel Margin="20"
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Top">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="420" />
+        </Grid.ColumnDefinitions>
+
+        <!-- Centro (formulario y teclado) -->
+        <Grid Grid.Column="0" Margin="40,0,20,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+            <StackPanel Grid.Row="0" HorizontalAlignment="Center">
                 <TextBlock Text="INGRESO DE NÚMERO DE PASE"
                            FontSize="36"
                            FontWeight="Bold"
@@ -36,18 +42,32 @@
                            TextWrapping="Wrap"
                            TextAlignment="Center"
                            Margin="0,0,0,20" />
-                <uc:TecladoNumerico Text="{Binding CodigoQR, Mode=TwoWay}" ComandoOk="{Binding EscanearQrCommand}" Margin="0,0,0,10" />
-                <TextBlock Text="{Binding Nombre, StringFormat=Nombre: {0}}" Margin="0,0,0,5" />
-                <TextBlock Text="{Binding Empresa, StringFormat=Empresa: {0}}" Margin="0,0,0,5" />
-
-                <Button Content="Ingresar" Command="{Binding IngresarCommand}" Width="100" Margin="0,0,0,10" Click="IngresarButton_Click" />
-                <StackPanel Visibility="{Binding IngresoRealizado, Converter={StaticResource BoolToVis}}">
-                    <TextBlock Text="{Binding HoraLlegada, StringFormat=Hora de llegada: {0:HH\\:mm}}" Margin="0,0,0,5" />
-                    <Image Source="{Binding QrImagePath}" Height="100" Width="100" Margin="0,0,0,5" />
-                    <Button Content="Imprimir QR de Salida" Command="{Binding ImprimirQrCommand}" Width="180" />
-                </StackPanel>
             </StackPanel>
-        </ScrollViewer>
+
+            <Viewbox Grid.Row="1"
+                     Stretch="Uniform"
+                     StretchDirection="DownOnly"
+                     MaxWidth="480">
+                <uc:TecladoNumerico Text="{Binding CodigoQR, Mode=TwoWay}"
+                                    ComandoOk="{Binding EscanearQrCommand}"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Top"
+                                    Width="420" />
+            </Viewbox>
+        </Grid>
+
+        <!-- Panel derecho Datos -->
+        <StackPanel Grid.Column="1" Margin="20,0,0,0">
+            <TextBlock Text="{Binding Nombre, StringFormat=Nombre: {0}}" Margin="0,0,0,5" />
+            <TextBlock Text="{Binding Empresa, StringFormat=Empresa: {0}}" Margin="0,0,0,5" />
+
+            <Button Content="Ingresar" Command="{Binding IngresarCommand}" Width="100" Margin="0,0,0,10" Click="IngresarButton_Click" />
+            <StackPanel Visibility="{Binding IngresoRealizado, Converter={StaticResource BoolToVis}}">
+                <TextBlock Text="{Binding HoraLlegada, StringFormat=Hora de llegada: {0:HH\\:mm}}" Margin="0,0,0,5" />
+                <Image Source="{Binding QrImagePath}" Height="100" Width="100" Margin="0,0,0,5" />
+                <Button Content="Imprimir QR de Salida" Command="{Binding ImprimirQrCommand}" Width="180" />
+            </StackPanel>
+        </StackPanel>
     </Grid>
 </UserControl>
 

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
@@ -20,19 +20,44 @@
         </Style>
     </UserControl.Resources>
     <Grid Background="{StaticResource StandardBackground}">
-        <StackPanel Margin="20" HorizontalAlignment="Center">
-            <TextBlock Text="INGRESO DE NÚMERO DE PASE DE SALIDA"
-                       FontSize="36"
-                       FontWeight="Bold"
-                       TextAlignment="Center"
-                       Margin="0,0,0,10" />
-            <TextBlock Text="Digite el número de pase del conductor y luego presione el botón verde OK."
-                       TextWrapping="Wrap"
-                       TextAlignment="Center"
-                       Margin="0,0,0,20" />
-            <uc:TecladoNumerico Text="{Binding NumeroPaseSalida, Mode=TwoWay}"
-                                ComandoOk="{Binding ProcesarSalidaCommand}"
-                                Margin="0,0,0,10" />
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="420" />
+        </Grid.ColumnDefinitions>
+
+        <!-- Centro (formulario y teclado) -->
+        <Grid Grid.Column="0" Margin="40,0,20,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+            <StackPanel Grid.Row="0" HorizontalAlignment="Center">
+                <TextBlock Text="INGRESO DE NÚMERO DE PASE DE SALIDA"
+                           FontSize="36"
+                           FontWeight="Bold"
+                           TextAlignment="Center"
+                           Margin="0,0,0,10" />
+                <TextBlock Text="Digite el número de pase del conductor y luego presione el botón verde OK."
+                           TextWrapping="Wrap"
+                           TextAlignment="Center"
+                           Margin="0,0,0,20" />
+            </StackPanel>
+
+            <Viewbox Grid.Row="1"
+                     Stretch="Uniform"
+                     StretchDirection="DownOnly"
+                     MaxWidth="480">
+                <uc:TecladoNumerico Text="{Binding NumeroPaseSalida, Mode=TwoWay}"
+                                    ComandoOk="{Binding ProcesarSalidaCommand}"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Top"
+                                    Width="420" />
+            </Viewbox>
+        </Grid>
+
+        <!-- Panel derecho Datos -->
+        <StackPanel Grid.Column="1" Margin="20,0,0,0">
             <TextBlock Text="{Binding MensajeError}" Foreground="Red" Margin="0,0,0,5" />
             <TextBlock Text="{Binding Nombre, StringFormat=Nombre: {0}}" Margin="0,0,0,5" />
             <TextBlock Text="{Binding Empresa, StringFormat=Empresa: {0}}" Margin="0,0,0,5" />
@@ -44,3 +69,4 @@
         </StackPanel>
     </Grid>
 </UserControl>
+


### PR DESCRIPTION
## Summary
- Centrar el `TecladoNumerico` en las vistas de entrada y salida usando un Grid con columna fija para el panel de datos.
- Ajustar el ancho del control y envolverlo en un `Viewbox` para evitar estiramientos y permitir reducción en pantallas pequeñas.

## Testing
- `msbuild ControlesAccesoQR/ControlesAccesoQR.csproj /t:Build /p:Configuration=Debug` *(falla: comando no encontrado)*
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj -c Debug` *(falla: comando no encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_689a9a215c60833093729b787f1f9bf2