### PR TITLE
Center numeric keypad in VistaEntradaSalida

### DIFF
--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
@@ -48,11 +48,13 @@
                      Stretch="Uniform"
                      StretchDirection="DownOnly"
                      MaxWidth="480">
-                <uc:TecladoNumerico Text="{Binding CodigoQR, Mode=TwoWay}"
-                                    ComandoOk="{Binding EscanearQrCommand}"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Top"
-                                    Width="420" />
+                <Grid HorizontalAlignment="Center">
+                    <uc:TecladoNumerico Text="{Binding CodigoQR, Mode=TwoWay}"
+                                        ComandoOk="{Binding EscanearQrCommand}"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Top"
+                                        Width="420" />
+                </Grid>
             </Viewbox>
         </Grid>
 


### PR DESCRIPTION
## Summary
- Center the numeric keypad by wrapping it in a Grid with horizontal centering

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689a9e6d49348330b8e0ed61a74d50e3