### PR TITLE
Open main window maximized and center numeric keypad

### DIFF
--- a/ControlesAccesoQR/MainWindow.xaml
+++ b/ControlesAccesoQR/MainWindow.xaml
@@ -4,9 +4,9 @@
         xmlns:estados="clr-namespace:ControlesAccesoQR.Estados"
         xmlns:conv="clr-namespace:ControlesAccesoQR.Converters"
         Title="ControlesAccesoQR"
-        Height="450"
-        Width="800"
+        WindowState="Maximized"
         WindowStartupLocation="CenterScreen"
+        SizeToContent="Manual"
         FontFamily="Microsoft Sans Serif">
     <Window.Resources>
         <LinearGradientBrush x:Key="StandardBackground" EndPoint="0.504,1.5" StartPoint="0.504,0.03">

--- a/ControlesAccesoQR/MainWindow.xaml.cs
+++ b/ControlesAccesoQR/MainWindow.xaml.cs
@@ -8,6 +8,11 @@ namespace ControlesAccesoQR
         public MainWindow()
         {
             InitializeComponent();
+            Loaded += (_, __) =>
+            {
+                WindowState = WindowState.Maximized;
+                Activate();
+            };
             DataContext = new MainWindowViewModel(MainFrame);
         }
 

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
@@ -44,18 +44,22 @@
                            Margin="0,0,0,20" />
             </StackPanel>
 
-            <Viewbox Grid.Row="1"
-                     Stretch="Uniform"
-                     StretchDirection="DownOnly"
-                     MaxWidth="480">
-                <Grid HorizontalAlignment="Center">
+            <Grid Grid.Row="1">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <Viewbox Grid.Column="1"
+                         Stretch="Uniform"
+                         StretchDirection="DownOnly"
+                         MaxWidth="480">
                     <uc:TecladoNumerico Text="{Binding CodigoQR, Mode=TwoWay}"
                                         ComandoOk="{Binding EscanearQrCommand}"
-                                        HorizontalAlignment="Center"
-                                        VerticalAlignment="Top"
                                         Width="420" />
-                </Grid>
-            </Viewbox>
+                </Viewbox>
+            </Grid>
         </Grid>
 
         <!-- Panel derecho Datos -->

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
@@ -27,13 +27,12 @@
 
         <!-- Centro (formulario y teclado) -->
         <Grid Grid.Column="0" Margin="40,0,20,0">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
 
-            <StackPanel Grid.Column="1" HorizontalAlignment="Center">
+            <StackPanel Grid.Row="0" HorizontalAlignment="Center">
                 <TextBlock Text="INGRESO DE NÚMERO DE PASE DE SALIDA"
                            FontSize="36"
                            FontWeight="Bold"
@@ -43,19 +42,30 @@
                            TextWrapping="Wrap"
                            TextAlignment="Center"
                            Margin="0,0,0,20" />
-                <Viewbox Stretch="Uniform"
-                         StretchDirection="DownOnly"
-                         MaxWidth="480"
-                         Margin="0,0,0,10">
-                    <uc:TecladoNumerico Text="{Binding NumeroPaseSalida, Mode=TwoWay}"
-                                        ComandoOk="{Binding ProcesarSalidaCommand}"
-                                        Width="420" />
-                </Viewbox>
-                <TextBlock Text="{Binding MensajeError}"
-                           Foreground="Red"
-                           TextAlignment="Center"
-                           Margin="0,0,0,5" />
             </StackPanel>
+
+            <Grid Grid.Row="1">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <StackPanel Grid.Column="1" HorizontalAlignment="Center">
+                    <Viewbox Stretch="Uniform"
+                             StretchDirection="DownOnly"
+                             MaxWidth="480"
+                             Margin="0,0,0,10">
+                        <uc:TecladoNumerico Text="{Binding NumeroPaseSalida, Mode=TwoWay}"
+                                            ComandoOk="{Binding ProcesarSalidaCommand}"
+                                            Width="420" />
+                    </Viewbox>
+                    <TextBlock Text="{Binding MensajeError}"
+                               Foreground="Red"
+                               TextAlignment="Center"
+                               Margin="0,0,0,5" />
+                </StackPanel>
+            </Grid>
         </Grid>
 
         <!-- Panel derecho Datos -->


### PR DESCRIPTION
## Summary
- Start `MainWindow` maximized and force maximization on load
- Center numeric keypad in entry and exit views using a three-column grid

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_689aac7d80288330b2fbe372ae286ec7