### PR TITLE
Center fields below keypad in entry view

### DIFF
--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
@@ -20,53 +20,68 @@
         </Style>
     </UserControl.Resources>
     <Grid Background="{StaticResource StandardBackground}">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="420" />
-        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" /> <!-- Título -->
+            <RowDefinition Height="Auto" /> <!-- Subtítulo -->
+            <RowDefinition Height="Auto" /> <!-- Teclado -->
+            <RowDefinition Height="Auto" /> <!-- Campos -->
+            <RowDefinition Height="Auto" /> <!-- Botón -->
+            <RowDefinition Height="Auto" /> <!-- Información adicional -->
+        </Grid.RowDefinitions>
 
-        <!-- Centro (formulario y teclado) -->
-        <Grid Grid.Column="1">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="*" />
-            </Grid.RowDefinitions>
+        <!-- Título -->
+        <TextBlock Grid.Row="0"
+                   Text="INGRESO DE NÚMERO DE PASE"
+                   FontSize="36"
+                   FontWeight="Bold"
+                   HorizontalAlignment="Center"
+                   Margin="0,0,0,10" />
 
-            <StackPanel Grid.Row="0" HorizontalAlignment="Center">
-                <TextBlock Text="INGRESO DE NÚMERO DE PASE"
-                           FontSize="36"
-                           FontWeight="Bold"
-                           TextAlignment="Center"
-                           Margin="0,0,0,10" />
-                <TextBlock Text="Digite el número de pase del conductor y luego presione el botón verde OK."
-                           TextWrapping="Wrap"
-                           TextAlignment="Center"
-                           Margin="0,0,0,20" />
-            </StackPanel>
+        <!-- Subtítulo -->
+        <TextBlock Grid.Row="1"
+                   Text="Digite el número de pase del conductor y luego presione el botón verde OK."
+                   TextWrapping="Wrap"
+                   TextAlignment="Center"
+                   HorizontalAlignment="Center"
+                   Margin="0,0,0,20" />
 
-            <Viewbox Grid.Row="1"
-                     Stretch="Uniform"
-                     StretchDirection="DownOnly"
-                     MaxWidth="480">
-                <uc:TecladoNumerico Text="{Binding CodigoQR, Mode=TwoWay}"
-                                    ComandoOk="{Binding EscanearQrCommand}"
-                                    Width="420" />
-            </Viewbox>
-        </Grid>
+        <!-- Teclado -->
+        <Viewbox Grid.Row="2"
+                 HorizontalAlignment="Center"
+                 Stretch="Uniform"
+                 StretchDirection="DownOnly"
+                 MaxWidth="480"
+                 Margin="0,0,0,10">
+            <uc:TecladoNumerico Text="{Binding CodigoQR, Mode=TwoWay}"
+                                ComandoOk="{Binding EscanearQrCommand}"
+                                Width="420" />
+        </Viewbox>
 
-        <!-- Panel derecho Datos -->
-        <StackPanel Grid.Column="3" Margin="20,0,0,0">
+        <!-- Campos -->
+        <StackPanel Grid.Row="3"
+                    Orientation="Vertical"
+                    HorizontalAlignment="Center"
+                    Margin="0,0,0,10">
             <TextBlock Text="{Binding Nombre, StringFormat=Nombre: {0}}" Margin="0,0,0,5" />
             <TextBlock Text="{Binding Empresa, StringFormat=Empresa: {0}}" Margin="0,0,0,5" />
+        </StackPanel>
 
-            <Button Content="Ingresar" Command="{Binding IngresarCommand}" Width="100" Margin="0,0,0,10" Click="IngresarButton_Click" />
-            <StackPanel Visibility="{Binding IngresoRealizado, Converter={StaticResource BoolToVis}}">
-                <TextBlock Text="{Binding HoraLlegada, StringFormat=Hora de llegada: {0:HH\\:mm}}" Margin="0,0,0,5" />
-                <Image Source="{Binding QrImagePath}" Height="100" Width="100" Margin="0,0,0,5" />
-                <Button Content="Imprimir QR de Salida" Command="{Binding ImprimirQrCommand}" Width="180" />
-            </StackPanel>
+        <!-- Botón -->
+        <Button Grid.Row="4"
+                Content="Ingresar"
+                Command="{Binding IngresarCommand}"
+                Width="100"
+                HorizontalAlignment="Center"
+                Margin="0,0,0,10"
+                Click="IngresarButton_Click" />
+
+        <!-- Información adicional -->
+        <StackPanel Grid.Row="5"
+                    Visibility="{Binding IngresoRealizado, Converter={StaticResource BoolToVis}}"
+                    HorizontalAlignment="Center">
+            <TextBlock Text="{Binding HoraLlegada, StringFormat=Hora de llegada: {0:HH\\:mm}}" Margin="0,0,0,5" />
+            <Image Source="{Binding QrImagePath}" Height="100" Width="100" Margin="0,0,0,5" />
+            <Button Content="Imprimir QR de Salida" Command="{Binding ImprimirQrCommand}" Width="180" />
         </StackPanel>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary
- Rework `VistaEntradaSalida` layout into a single-column grid.
- Place name and company fields and the Ingresar button beneath the numeric keypad, keeping all elements centered.
- Preserve keypad centering and add an area for post-entry information.

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_689ab19be3b4833082625903a8e9b8fd