### PR TITLE
Restore Pase step in control panel

### DIFF
--- a/ControlesAccesoQR/MainWindow.xaml
+++ b/ControlesAccesoQR/MainWindow.xaml
@@ -109,14 +109,14 @@
                                                 <Style TargetType="TextBlock">
                                                     <Setter Property="Text" Value="" />
                                                     <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding}" Value="{x:Static estados:EstadoProceso.Pase}">
+                                                            <Setter Property="Text" Value="🔢" />
+                                                        </DataTrigger>
                                                         <DataTrigger Binding="{Binding}" Value="{x:Static estados:EstadoProceso.Huella}">
                                                             <Setter Property="Text" Value="🖐" />
                                                         </DataTrigger>
                                                         <DataTrigger Binding="{Binding}" Value="{x:Static estados:EstadoProceso.Tag}">
                                                             <Setter Property="Text" Value="🏷" />
-                                                        </DataTrigger>
-                                                        <DataTrigger Binding="{Binding}" Value="{x:Static estados:EstadoProceso.Pase}">
-                                                            <Setter Property="Text" Value="🔢" />
                                                         </DataTrigger>
                                                         <DataTrigger Binding="{Binding}" Value="{x:Static estados:EstadoProceso.Ticket}">
                                                             <Setter Property="Text" Value="🎫" />

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
@@ -37,7 +37,13 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
 
         public ObservableCollection<Proceso> Procesos { get; } = new ObservableCollection<Proceso>();
 
-        public IEnumerable<EstadoPanel> Estados { get; } = Enum.GetValues(typeof(EstadoPanel)).Cast<EstadoPanel>();
+        public IEnumerable<EstadoPanel> Estados { get; } = new[]
+        {
+            EstadoPanel.Pase,
+            EstadoPanel.Huella,
+            EstadoPanel.Tag,
+            EstadoPanel.Ticket
+        };
 
         public ICommand MostrarEntradaSalidaCommand { get; }
         public ICommand MostrarSalidaFinalCommand { get; }


### PR DESCRIPTION
## Summary
- Show Pase state at top of the status panel
- Explicitly include Pase in states collection for correct ordering

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(failed: command not found)*
- `apt-get update` *(failed: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_689ab689bd9c8330b809e915c2d3f0f1