### PR TITLE
Restaurar sección Kiosco en panel de datos

### DIFF
--- a/ControlesAccesoQR/MainWindow.xaml
+++ b/ControlesAccesoQR/MainWindow.xaml
@@ -127,23 +127,34 @@
                             </ItemsControl.ItemTemplate>
                         </ItemsControl>
 
-                        <Border Background="Transparent"
-                                Margin="0"
-                                Padding="16,12"
-                                HorizontalAlignment="Stretch"
-                                TextElement.Foreground="#9E9E9E">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="80" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <Image Grid.Column="0" Source="Assets/Logo.png" Height="36" Width="36" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                                <StackPanel Grid.Column="1" VerticalAlignment="Center" Margin="20,0,0,0">
-                                    <TextBlock Text="Kiosco" FontSize="36" />
-                                    <TextBlock Text="{Binding TipoKioscoTexto}" FontSize="20" />
-                                </StackPanel>
-                            </Grid>
-                        </Border>
+                        <!-- Sección Kiosco (no es estado) -->
+                        <StackPanel Margin="16,24,16,0">
+                            <TextBlock Text="{Binding KioscoTitulo}"
+                                       FontSize="24" FontWeight="Bold" />
+
+                            <!-- Tarjeta del número -->
+                            <Border Background="#EF6C00" CornerRadius="8"
+                                    Margin="0,8,0,8" Padding="24"
+                                    HorizontalAlignment="Stretch">
+                                <TextBlock Text="{Binding NumeroKiosco}"
+                                           Foreground="White"
+                                           FontSize="64"
+                                           FontWeight="Bold"
+                                           HorizontalAlignment="Center"/>
+                            </Border>
+
+                            <!-- Fecha/Hora -->
+                            <TextBlock Text="{Binding FechaHora}"
+                                       FontSize="16"
+                                       Foreground="#444"
+                                       HorizontalAlignment="Center" />
+
+                            <!-- Logo (si hay recurso); si no, placeholder -->
+                            <Border Background="#BDBDBD" CornerRadius="6"
+                                    Margin="0,12,0,0" Height="80">
+                                <Image Source="{Binding KioscoLogo}" Stretch="Uniform" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                        </StackPanel>
                     </StackPanel>
                 </ScrollViewer>
             </Grid>

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
@@ -7,6 +7,8 @@ using System.Net;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 using ControlesAccesoQR.Models;
 using ControlesAccesoQR.Views.ControlesAccesoQR;
@@ -53,6 +55,10 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         public bool IsKioskEntrada { get; private set; }
 
         public string TipoKioscoTexto => IsKioskEntrada ? "Entrada" : "Salida";
+
+        public string KioscoTitulo => "Kiosco";
+
+        public ImageSource KioscoLogo { get; } = new BitmapImage(new Uri("pack://application:,,,/ControlesAccesoQR;component/Assets/Logo.png"));
 
         public EstadoPanel EstadoActual
         {


### PR DESCRIPTION
## Summary
- Añadido bloque "Kiosco" al final del panel de datos con tarjeta naranja, fecha/hora y logo.
- Expuestas propiedades `KioscoTitulo` y `KioscoLogo` en `MainWindowViewModel` para soportar el nuevo bloque.

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` (falló: command not found)
- `apt-get update` (falló: repository not signed)
- `apt-get install -y dotnet-sdk-7.0` (falló: package not found)


------
https://chatgpt.com/codex/tasks/task_e_689af0da579c83309acc270e3b343ed5