### PR TITLE
Oculta cabecera superior de MainWindow

### DIFF
--- a/ControlesAccesoQR/MainWindow.xaml
+++ b/ControlesAccesoQR/MainWindow.xaml
@@ -31,7 +31,7 @@
 
         <!-- Panel principal -->
         <DockPanel Grid.Column="0">
-            <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="10">
+            <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Margin="10" Visibility="Collapsed">
                 <TextBlock Text="{Binding NumeroKiosco}" FontSize="20" Margin="0,0,20,0" VerticalAlignment="Center" />
                 <Button Content="Abrir pantalla de test RFID" Click="AbrirRfIdTest_Click" Margin="10,0,0,0" />
             </StackPanel>


### PR DESCRIPTION
## Summary
- Oculta la cabecera superior con número de kiosco y botón de pruebas RFID para que no se muestre en la interfaz.

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(falla: command not found)*
- `apt-get update` *(falla: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689af1a93600833099ef1d79eaae417b