### PR TITLE
feat: unify pass input for keyboard and QR scans

### DIFF
--- a/ControlesAccesoQR/UserControls/TecladoNumerico.xaml
+++ b/ControlesAccesoQR/UserControls/TecladoNumerico.xaml
@@ -19,8 +19,8 @@
                  Width="380"
                  Height="70"
                  Margin="0,0,0,20"
-                 IsReadOnly="True"
                  Style="{StaticResource Tx.TextBoxLarge}"
+                 KeyDown="InputTextBox_KeyDown"
                  Text="{Binding Text, RelativeSource={RelativeSource AncestorType=UserControl}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
         <UniformGrid x:Name="NumbersGrid" Grid.Row="1" Columns="3" Rows="4" Margin="0,0,10,0">

--- a/ControlesAccesoQR/UserControls/TecladoNumerico.xaml.cs
+++ b/ControlesAccesoQR/UserControls/TecladoNumerico.xaml.cs
@@ -59,6 +59,16 @@ namespace ControlesAccesoQR.UserControls
             InputTextBox.Focus();
         }
 
+        private void InputTextBox_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                if (ComandoOk?.CanExecute(null) == true)
+                    ComandoOk.Execute(null);
+                e.Handled = true;
+            }
+        }
+
         private void UserControl_Loaded(object sender, RoutedEventArgs e)
         {
             InputTextBox.Focus();

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
@@ -3,7 +3,9 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:conv="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
              xmlns:uc="clr-namespace:ControlesAccesoQR.UserControls"
-             FontFamily="Microsoft Sans Serif">
+             FontFamily="Microsoft Sans Serif"
+             PreviewTextInput="UserControl_PreviewTextInput"
+             PreviewKeyDown="UserControl_PreviewKeyDown">
     <UserControl.Resources>
         <conv:BooleanToVisibilityConverter x:Key="BoolToVis" />
     </UserControl.Resources>
@@ -34,7 +36,7 @@
 
         <!-- Teclado -->
         <Viewbox Grid.Row="3" Grid.Column="1" HorizontalAlignment="Center" Stretch="Uniform" StretchDirection="DownOnly" MaxWidth="480" Margin="0,0,0,16">
-            <uc:TecladoNumerico Text="{Binding CodigoQR, Mode=TwoWay}" ComandoOk="{Binding EscanearQrCommand}" Width="420" />
+            <uc:TecladoNumerico Text="{Binding CodigoQR, Mode=TwoWay}" ComandoOk="{Binding SubmitPassCommand}" Width="420" />
         </Viewbox>
 
         <!-- Campos -->


### PR DESCRIPTION
## Summary
- add `SubmitPassAsync` to validate pass numbers from keyboard or QR reader
- handle QR scanner input with debounce and timeout
- allow physical keyboard entry and Enter key submission

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689cddeffd248330b831608a644ace2a