### PR TITLE
Fix converter namespace in ControlesAccesoQR views

### DIFF
--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="ControlesAccesoQR.Views.ControlesAccesoQR.VistaEntradaSalida"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:conv="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
+            xmlns:conv="clr-namespace:System.Windows;assembly=PresentationFramework"
              xmlns:uc="clr-namespace:ControlesAccesoQR.UserControls"
              FontFamily="Microsoft Sans Serif"
              PreviewTextInput="UserControl_PreviewTextInput"

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="ControlesAccesoQR.Views.ControlesAccesoQR.VistaSalidaFinal"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:conv="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
+            xmlns:conv="clr-namespace:System.Windows;assembly=PresentationFramework"
              xmlns:uc="clr-namespace:ControlesAccesoQR.UserControls"
              FontFamily="Microsoft Sans Serif">
     <UserControl.Resources>


### PR DESCRIPTION
## Summary
- Correct `BooleanToVisibilityConverter` namespace reference in `VistaEntradaSalida` view
- Correct converter namespace in `VistaSalidaFinal` view

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ce5e4629883309d5b4e8be67ce338