### PR TITLE
fix: direct BooleanToVisibilityConverter usage in WPF views

### DIFF
--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
@@ -1,13 +1,12 @@
 <UserControl x:Class="ControlesAccesoQR.Views.ControlesAccesoQR.VistaEntradaSalida"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:conv="clr-namespace:System.Windows;assembly=PresentationFramework"
              xmlns:uc="clr-namespace:ControlesAccesoQR.UserControls"
              FontFamily="Microsoft Sans Serif"
              PreviewTextInput="UserControl_PreviewTextInput"
              PreviewKeyDown="UserControl_PreviewKeyDown">
     <UserControl.Resources>
-        <conv:BooleanToVisibilityConverter x:Key="BoolToVis" />
+        <BooleanToVisibilityConverter x:Key="BoolToVis" />
     </UserControl.Resources>
     <Grid UseLayoutRounding="True" SnapsToDevicePixels="True">
         <Grid.RowDefinitions>

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
@@ -1,11 +1,10 @@
 <UserControl x:Class="ControlesAccesoQR.Views.ControlesAccesoQR.VistaSalidaFinal"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:conv="clr-namespace:System.Windows;assembly=PresentationFramework"
              xmlns:uc="clr-namespace:ControlesAccesoQR.UserControls"
              FontFamily="Microsoft Sans Serif">
     <UserControl.Resources>
-        <conv:BooleanToVisibilityConverter x:Key="BoolToVis" />
+        <BooleanToVisibilityConverter x:Key="BoolToVis" />
     </UserControl.Resources>
     <Grid UseLayoutRounding="True" SnapsToDevicePixels="True">
         <Grid.RowDefinitions>


### PR DESCRIPTION
## Summary
- declare `BooleanToVisibilityConverter` directly in `VistaEntradaSalida` and `VistaSalidaFinal` resources
- remove unnecessary namespace declaration for the converter

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689cea0a30388330bbe5cbd50489e559