### PR TITLE
refactor: align view namespaces with root

### DIFF
--- a/ControlesAccesoQR/ControlesAccesoQR.csproj
+++ b/ControlesAccesoQR/ControlesAccesoQR.csproj
@@ -93,23 +93,23 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="Views\ControlesAccesoQR\VistaEntradaSalida.xaml">
+    <Page Include="Views\EntradaSalida\VistaEntradaSalida.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="Views\ControlesAccesoQR\DialogoQr.xaml">
+    <Page Include="Views\EntradaSalida\DialogoQr.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="Views\ControlesAccesoQR\VistaSalidaFinal.xaml">
+    <Page Include="Views\EntradaSalida\VistaSalidaFinal.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="Views\ControlesAccesoQR\DialogoHuella.xaml">
+    <Page Include="Views\EntradaSalida\DialogoHuella.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="Views\ControlesAccesoQR\EstadoProcesoPanel.xaml">
+    <Page Include="Views\EntradaSalida\EstadoProcesoPanel.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -146,19 +146,19 @@
     <Compile Include="Estados\EstadoProceso.cs" />
     <Compile Include="Converters\EqualityConverter.cs" />
     <Compile Include="Converters\SetContainsConverter.cs" />
-    <Compile Include="Views\ControlesAccesoQR\VistaEntradaSalida.xaml.cs">
+    <Compile Include="Views\EntradaSalida\VistaEntradaSalida.xaml.cs">
       <DependentUpon>VistaEntradaSalida.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Views\ControlesAccesoQR\DialogoHuella.xaml.cs">
+    <Compile Include="Views\EntradaSalida\DialogoHuella.xaml.cs">
       <DependentUpon>DialogoHuella.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Views\ControlesAccesoQR\DialogoQr.xaml.cs">
+    <Compile Include="Views\EntradaSalida\DialogoQr.xaml.cs">
       <DependentUpon>DialogoQr.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Views\ControlesAccesoQR\VistaSalidaFinal.xaml.cs">
+    <Compile Include="Views\EntradaSalida\VistaSalidaFinal.xaml.cs">
       <DependentUpon>VistaSalidaFinal.xaml</DependentUpon>
     </Compile>
-    <Compile Include="Views\ControlesAccesoQR\EstadoProcesoPanel.xaml.cs">
+    <Compile Include="Views\EntradaSalida\EstadoProcesoPanel.xaml.cs">
       <DependentUpon>EstadoProcesoPanel.xaml</DependentUpon>
     </Compile>
     <Compile Include="AsyncRelayCommand.cs" />

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
@@ -11,7 +11,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 using ControlesAccesoQR.Models;
-using ControlesAccesoQR.Views.ControlesAccesoQR;
+using ControlesAccesoQR.Views.EntradaSalida;
 using ControlesAccesoQR.Servicios;
 
 using EstadoPanel = ControlesAccesoQR.Estados.EstadoProceso;

--- a/ControlesAccesoQR/Views/EntradaSalida/DialogoHuella.xaml
+++ b/ControlesAccesoQR/Views/EntradaSalida/DialogoHuella.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="ControlesAccesoQR.Views.ControlesAccesoQR.DialogoHuella"
+<Window x:Class="ControlesAccesoQR.Views.EntradaSalida.DialogoHuella"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Validar Huella" Height="180" Width="300" WindowStartupLocation="CenterOwner"

--- a/ControlesAccesoQR/Views/EntradaSalida/DialogoHuella.xaml.cs
+++ b/ControlesAccesoQR/Views/EntradaSalida/DialogoHuella.xaml.cs
@@ -1,6 +1,6 @@
 using System.Windows;
 
-namespace ControlesAccesoQR.Views.ControlesAccesoQR
+namespace ControlesAccesoQR.Views.EntradaSalida
 {
     public partial class DialogoHuella : Window
     {

--- a/ControlesAccesoQR/Views/EntradaSalida/DialogoQr.xaml
+++ b/ControlesAccesoQR/Views/EntradaSalida/DialogoQr.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="ControlesAccesoQR.Views.ControlesAccesoQR.DialogoQr"
+<Window x:Class="ControlesAccesoQR.Views.EntradaSalida.DialogoQr"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Title="Escanear QR" Height="150" Width="300" WindowStartupLocation="CenterOwner"

--- a/ControlesAccesoQR/Views/EntradaSalida/DialogoQr.xaml.cs
+++ b/ControlesAccesoQR/Views/EntradaSalida/DialogoQr.xaml.cs
@@ -1,6 +1,6 @@
 using System.Windows;
 
-namespace ControlesAccesoQR.Views.ControlesAccesoQR
+namespace ControlesAccesoQR.Views.EntradaSalida
 {
     public partial class DialogoQr : Window
     {

--- a/ControlesAccesoQR/Views/EntradaSalida/EstadoProcesoPanel.xaml
+++ b/ControlesAccesoQR/Views/EntradaSalida/EstadoProcesoPanel.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="ControlesAccesoQR.Views.ControlesAccesoQR.EstadoProcesoPanel"
+<UserControl x:Class="ControlesAccesoQR.Views.EntradaSalida.EstadoProcesoPanel"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:models="clr-namespace:ControlesAccesoQR.Models"

--- a/ControlesAccesoQR/Views/EntradaSalida/EstadoProcesoPanel.xaml.cs
+++ b/ControlesAccesoQR/Views/EntradaSalida/EstadoProcesoPanel.xaml.cs
@@ -1,6 +1,6 @@
 using System.Windows.Controls;
 
-namespace ControlesAccesoQR.Views.ControlesAccesoQR
+namespace ControlesAccesoQR.Views.EntradaSalida
 {
     public partial class EstadoProcesoPanel : UserControl
     {

--- a/ControlesAccesoQR/Views/EntradaSalida/VistaEntradaSalida.xaml
+++ b/ControlesAccesoQR/Views/EntradaSalida/VistaEntradaSalida.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="ControlesAccesoQR.Views.ControlesAccesoQR.VistaEntradaSalida"
+<UserControl x:Class="ControlesAccesoQR.Views.EntradaSalida.VistaEntradaSalida"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:uc="clr-namespace:ControlesAccesoQR.UserControls"

--- a/ControlesAccesoQR/Views/EntradaSalida/VistaEntradaSalida.xaml.cs
+++ b/ControlesAccesoQR/Views/EntradaSalida/VistaEntradaSalida.xaml.cs
@@ -10,7 +10,7 @@ using ControlesAccesoQR.ViewModels.ControlesAccesoQR;
 using ControlesAccesoQR.Models;
 using EstadoProcesoTipo = ControlesAccesoQR.Models.EstadoProceso;
 
-namespace ControlesAccesoQR.Views.ControlesAccesoQR
+namespace ControlesAccesoQR.Views.EntradaSalida
 {
     public partial class VistaEntradaSalida : UserControl
     {

--- a/ControlesAccesoQR/Views/EntradaSalida/VistaSalidaFinal.xaml
+++ b/ControlesAccesoQR/Views/EntradaSalida/VistaSalidaFinal.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="ControlesAccesoQR.Views.ControlesAccesoQR.VistaSalidaFinal"
+<UserControl x:Class="ControlesAccesoQR.Views.EntradaSalida.VistaSalidaFinal"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:uc="clr-namespace:ControlesAccesoQR.UserControls"

--- a/ControlesAccesoQR/Views/EntradaSalida/VistaSalidaFinal.xaml.cs
+++ b/ControlesAccesoQR/Views/EntradaSalida/VistaSalidaFinal.xaml.cs
@@ -1,6 +1,6 @@
 using System.Windows.Controls;
 
-namespace ControlesAccesoQR.Views.ControlesAccesoQR
+namespace ControlesAccesoQR.Views.EntradaSalida
 {
     public partial class VistaSalidaFinal : UserControl
     {


### PR DESCRIPTION
## Summary
- Move QR access views into `Views/EntradaSalida`
- Update WPF view namespaces to `ControlesAccesoQR.Views.EntradaSalida`
- Adjust project file and view model references for new view path

## Testing
- ❌ `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` (dotnet: command not found)
- ⚠️ `apt-get update` (repository not signed)

------
https://chatgpt.com/codex/tasks/task_e_689cee73d8408330ae67bf289482c522