### PR TITLE
Integrar impresión automática tras ingreso

### DIFF
--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
@@ -184,6 +184,8 @@ namespace ControlesAccesoQR.Views.ControlesAccesoQR
                         if (!await vm.ActualizarEstadoAsync("R"))
                             return;
                         MessageBox.Show("RFID detectado");
+
+                        await EjecutarImpresionAsync(vm);
                         return;
                     }
 
@@ -194,6 +196,8 @@ namespace ControlesAccesoQR.Views.ControlesAccesoQR
                     await CompletarLecturaRfidAsync(vm, null);
                     if (!await vm.ActualizarEstadoAsync("R"))
                         return;
+
+                    await EjecutarImpresionAsync(vm);
                 }
             }
         }
@@ -201,16 +205,20 @@ namespace ControlesAccesoQR.Views.ControlesAccesoQR
         private async void ImprimirButton_Click(object sender, RoutedEventArgs e)
         {
             if (DataContext is VistaEntradaSalidaViewModel vm)
-            {
-                if (DevBypass.IsDevKiosk)
-                {
-                    await CompletarImpresionAsync(vm);
-                    if (!await vm.ActualizarEstadoAsync("P"))
-                        return;
-                    MessageBox.Show("Impresión simulada (CGDE041)");
-                    return;
-                }
+                await EjecutarImpresionAsync(vm);
+        }
 
+        private async Task EjecutarImpresionAsync(VistaEntradaSalidaViewModel vm)
+        {
+            if (DevBypass.IsDevKiosk)
+            {
+                await CompletarImpresionAsync(vm);
+                if (!await vm.ActualizarEstadoAsync("P"))
+                    return;
+                MessageBox.Show("Impresión simulada (CGDE041)");
+            }
+            else
+            {
                 await CompletarImpresionAsync(vm);
                 if (!await vm.ActualizarEstadoAsync("P"))
                     return;


### PR DESCRIPTION
## Summary
- Ejecutar impresión automática en IngresarButton_Click después de la lectura RFID.
- Extraer lógica de impresión a método compartido `EjecutarImpresionAsync`.
- Reutilizar `EjecutarImpresionAsync` en ImprimirButton_Click para evitar duplicación.

## Testing
- ⚠️ `dotnet test` (dotnet no instalado)
- ⚠️ `apt-get update` (repositorios no accesibles)
- ⚠️ `apt-get install -y dotnet-sdk-7.0` (paquete no localizado)


------
https://chatgpt.com/codex/tasks/task_e_689ea4b0be20833082d177f34b13d26c