### PR TITLE
Filtrar estados en VistaEntradaSalida

### DIFF
--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
@@ -38,13 +38,25 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
 
         public ObservableCollection<Proceso> Procesos { get; } = new ObservableCollection<Proceso>();
 
-        public IEnumerable<EstadoPanel> Estados { get; } = new[]
+        private static readonly EstadoPanel[] _todosLosEstados = new[]
         {
             EstadoPanel.Pase,
             EstadoPanel.Huella,
             EstadoPanel.Tag,
             EstadoPanel.Ticket
         };
+
+        private IEnumerable<EstadoPanel> _estados = _todosLosEstados;
+
+        public IEnumerable<EstadoPanel> Estados
+        {
+            get => _estados;
+            private set
+            {
+                _estados = value;
+                OnPropertyChanged(nameof(Estados));
+            }
+        }
 
         public string NumeroKiosco
         {
@@ -117,12 +129,20 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
 
         public void MostrarEntradaSalida()
         {
+            Estados = FiltrarEstadosPorCodigos(new[] { "Pase", "Tictek" });
             _frame.Navigate(new VistaEntradaSalida { DataContext = new VistaEntradaSalidaViewModel(this) });
         }
 
         public void MostrarSalidaFinal()
         {
+            Estados = _todosLosEstados;
             _frame.Navigate(new VistaSalidaFinal { DataContext = new VistaSalidaFinalViewModel(this) });
+        }
+
+        private IEnumerable<EstadoPanel> FiltrarEstadosPorCodigos(IEnumerable<string> codigos)
+        {
+            var permitidos = new HashSet<string>(codigos, StringComparer.OrdinalIgnoreCase);
+            return _todosLosEstados.Where(e => permitidos.Contains(e.ToString()));
         }
 
         public async Task ReiniciarDespuesDeSalidaAsync()


### PR DESCRIPTION
## Summary
- Filtra la lista de estados mostrados en el panel cuando se navega a **VistaEntradaSalida**, limitándola a los códigos "Pase" y "Tictek".
- Restablece la lista completa de estados al cambiar a otras vistas.

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(falló: comando no encontrado)*
- `apt-get update` *(falló: repositorios no disponibles, error 403)*

------
https://chatgpt.com/codex/tasks/task_e_689eb4fff42483309defefbf90756598