### PR TITLE
Convert VistaSalidaFinal to WPF Page

### DIFF
--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
@@ -1,10 +1,11 @@
-<UserControl x:Class="ControlesAccesoQR.Views.ControlesAccesoQR.VistaSalidaFinal"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:conv="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
-             xmlns:uc="clr-namespace:ControlesAccesoQR.UserControls"
-             FontFamily="Microsoft Sans Serif">
-    <UserControl.Resources>
+<Page x:Class="ControlesAccesoQR.Views.ControlesAccesoQR.VistaSalidaFinal"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:conv="clr-namespace:System.Windows.Controls;assembly=PresentationFramework"
+      xmlns:uc="clr-namespace:ControlesAccesoQR.UserControls"
+      Title="Salida Final"
+      FontFamily="Microsoft Sans Serif">
+    <Page.Resources>
         <conv:BooleanToVisibilityConverter x:Key="BoolToVis" />
         <LinearGradientBrush x:Key="StandardBackground" EndPoint="0.504,1.5" StartPoint="0.504,0.03">
             <GradientStop Color="#FFFFFF" Offset="0" />
@@ -18,7 +19,7 @@
         <Style TargetType="TextBlock">
             <Setter Property="FontSize" Value="20" />
         </Style>
-    </UserControl.Resources>
+    </Page.Resources>
     <Grid Background="{StaticResource StandardBackground}">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
@@ -73,5 +74,5 @@
             </StackPanel>
         </StackPanel>
     </Grid>
-</UserControl>
+</Page>
 

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml.cs
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml.cs
@@ -2,7 +2,7 @@ using System.Windows.Controls;
 
 namespace ControlesAccesoQR.Views.ControlesAccesoQR
 {
-    public partial class VistaSalidaFinal : UserControl
+    public partial class VistaSalidaFinal : Page
     {
         public VistaSalidaFinal()
         {


### PR DESCRIPTION
## Summary
- Convert VistaSalidaFinal view from `UserControl` to `Page` with a title
- Update VistaSalidaFinal code-behind to inherit from `Page`

## Testing
- `dotnet build ControlesAccesoQR.csproj` *(fails: command not found)*
- `msbuild ControlesAccesoQR.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a16cbe2e0083309a4d7d65cad1d35c