### PR TITLE
Fix kiosk entry/exit method selection

### DIFF
--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
@@ -129,13 +129,13 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
 
         public void MostrarEntradaSalida()
         {
-            Estados = FiltrarEstadosPorCodigos(new[] { "Pase", "Ticket" });
+            Estados = _todosLosEstados;
             _frame.Navigate(new VistaEntradaSalida { DataContext = new VistaEntradaSalidaViewModel(this) });
         }
 
         public void MostrarSalidaFinal()
         {
-            Estados = _todosLosEstados;
+            Estados = FiltrarEstadosPorCodigos(new[] { "Pase", "Ticket" });
             _frame.Navigate(new VistaSalidaFinal { DataContext = new VistaSalidaFinalViewModel(this) });
         }
 
@@ -177,9 +177,15 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
                 OnPropertyChanged(nameof(IsKioskEntrada));
                 OnPropertyChanged(nameof(TipoKioscoTexto));
                 if (IsKioskEntrada)
+                {
+                    // Entrada: mostrar todos los estados
                     MostrarEntradaSalida();
+                }
                 else
+                {
+                    // Salida: mostrar solo Pase y Ticket
                     MostrarSalidaFinal();
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- Correct `MostrarEntradaSalida` to display all states
- Restrict `MostrarSalidaFinal` to "Pase" and "Ticket" only
- Ensure kiosks invoke the appropriate method based on `IS_IN`

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a1872a24d0833094577bf2a7355360