### PR TITLE
feat: auto scan and print in VistaSalidaFinal

### DIFF
--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaSalidaFinalViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaSalidaFinalViewModel.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
+using System.Text.RegularExpressions;
 using ControlesAccesoQR;
 using ControlesAccesoQR.accesoDatos;
 using ControlesAccesoQR.Models;
@@ -41,12 +42,14 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
 
         public ObservableCollection<string> Contenedores { get; } = new ObservableCollection<string>();
 
+        public ICommand SubmitPassCommand { get; }
         public ICommand ProcesarSalidaCommand { get; }
         public ICommand ImprimirCommand { get; }
 
         public VistaSalidaFinalViewModel(MainWindowViewModel mainViewModel)
         {
             _mainViewModel = mainViewModel;
+            SubmitPassCommand = new RelayCommand(() => SubmitPass(NumeroPaseSalida, "manual"));
             ProcesarSalidaCommand = new AsyncRelayCommand(ProcesarSalidaAsync);
             ImprimirCommand = new RelayCommand(Imprimir, PuedeImprimir);
 
@@ -126,7 +129,55 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
 
             };
             _mainViewModel.EstadoProceso = EstadoProcesoEnum.SalidaRegistrada;
+            Imprimir();
             _ = _mainViewModel.ReiniciarDespuesDeSalidaAsync();
+        }
+
+        public void SubmitPass(string input, string inputMethod)
+        {
+            var normalized = NormalizeInput(input);
+            if (string.IsNullOrWhiteSpace(normalized))
+            {
+                MessageBox.Show("Número de pase inválido");
+                return;
+            }
+
+            if (!Regex.IsMatch(normalized, "^[A-Za-z0-9]+$"))
+            {
+                MessageBox.Show("Formato de número de pase inválido");
+                return;
+            }
+
+            NumeroPaseSalida = normalized;
+
+            var datos = _dataAccess.ObtenerChoferEmpresaPorPaseSalida(NumeroPaseSalida);
+            if (datos != null)
+            {
+                Nombre = datos.ChoferNombre;
+                Empresa = datos.EmpresaNombre;
+                Patente = datos.Patente;
+            }
+            else
+            {
+                MessageBox.Show("No se encontraron datos para el pase");
+            }
+        }
+
+        private string NormalizeInput(string input)
+        {
+            if (string.IsNullOrWhiteSpace(input))
+                return string.Empty;
+
+            var cleaned = input.Trim().Replace("\r", string.Empty).Replace("\n", string.Empty);
+
+            if (cleaned.StartsWith("URI:", StringComparison.OrdinalIgnoreCase))
+                cleaned = cleaned.Substring(4);
+
+            var match = Regex.Match(cleaned, @"passNumber[""':=]+([A-Za-z0-9-]+)");
+            if (match.Success)
+                return match.Groups[1].Value;
+
+            return cleaned;
         }
 
         private bool PuedeImprimir() => FechaSalida.HasValue;

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml
@@ -57,12 +57,13 @@
                  MaxWidth="480"
                  Margin="0,0,0,10">
             <uc:TecladoNumerico Text="{Binding NumeroPaseSalida, Mode=TwoWay}"
-                                ComandoOk="{Binding ProcesarSalidaCommand}"
+                                ComandoOk="{Binding SubmitPassCommand}"
                                 Width="420" />
         </Viewbox>
 
         <!-- Entrada del pase -->
-        <TextBox Grid.Row="3" Grid.ColumnSpan="2"
+        <TextBox x:Name="QrInput"
+                 Grid.Row="3" Grid.ColumnSpan="2"
                  Text="{Binding NumeroPaseSalida, UpdateSourceTrigger=PropertyChanged}"
                  HorizontalAlignment="Stretch"
                  Margin="0,0,0,8"

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml.cs
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaSalidaFinal.xaml.cs
@@ -1,12 +1,152 @@
+using System;
+using System.ComponentModel;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Threading;
+using ControlesAccesoQR.ViewModels.ControlesAccesoQR;
 
 namespace ControlesAccesoQR.Views.ControlesAccesoQR
 {
     public partial class VistaSalidaFinal : Page
     {
+        private readonly StringBuilder _qrBuffer = new StringBuilder();
+        private readonly DispatcherTimer _qrTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(1000) };
+        private string _lastScan = string.Empty;
+        private DateTime _lastScanTime = DateTime.MinValue;
+        private CancellationTokenSource _qrCts;
+        private bool _autoSubmitting;
+
         public VistaSalidaFinal()
         {
             InitializeComponent();
+            _qrTimer.Tick += QrTimer_Tick;
+            Loaded += VistaSalidaFinal_Loaded;
+            Unloaded += VistaSalidaFinal_Unloaded;
+
+            Loaded += (_, __) => { QrInput?.Focus(); };
+            DataContextChanged += (_, __) =>
+            {
+                if (DataContext is INotifyPropertyChanged npc)
+                {
+                    npc.PropertyChanged -= OnVmPropertyChanged;
+                    npc.PropertyChanged += OnVmPropertyChanged;
+                }
+            };
+        }
+
+        private void OnVmPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(VistaSalidaFinalViewModel.NumeroPaseSalida) || e.PropertyName == "NumeroPaseSalida")
+            {
+                DebouncedAutoProcesar(200);
+            }
+        }
+
+        private void DebouncedAutoProcesar(int delayMs)
+        {
+            _qrCts?.Cancel();
+            _qrCts = new CancellationTokenSource();
+            var token = _qrCts.Token;
+
+            Task.Run(async () =>
+            {
+                try
+                {
+                    await Task.Delay(delayMs, token);
+                    if (token.IsCancellationRequested) return;
+
+                    await Dispatcher.InvokeAsync(() =>
+                    {
+                        if (_autoSubmitting) return;
+                        _autoSubmitting = true;
+                        try
+                        {
+                            var vm = DataContext;
+                            var cmd = (vm?.GetType().GetProperty("ProcesarSalidaCommand")?.GetValue(vm)) as ICommand;
+                            var param = vm?.GetType().GetProperty("NumeroPaseSalida")?.GetValue(vm);
+                            if (cmd != null && cmd.CanExecute(param))
+                                cmd.Execute(param);
+                        }
+                        finally
+                        {
+                            _autoSubmitting = false;
+                        }
+                    });
+                }
+                catch (TaskCanceledException) { }
+            }, token);
+        }
+
+        private void VistaSalidaFinal_Loaded(object sender, RoutedEventArgs e)
+        {
+            var window = Window.GetWindow(this);
+            if (window != null)
+                window.PreviewKeyDown += Window_PreviewKeyDown;
+        }
+
+        private void VistaSalidaFinal_Unloaded(object sender, RoutedEventArgs e)
+        {
+            var window = Window.GetWindow(this);
+            if (window != null)
+                window.PreviewKeyDown -= Window_PreviewKeyDown;
+        }
+
+        private void Window_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (Keyboard.FocusedElement is TextBox)
+                return;
+
+            if (e.Key == Key.Enter)
+            {
+                _qrTimer.Stop();
+                var text = _qrBuffer.ToString();
+                _qrBuffer.Clear();
+                if (string.IsNullOrWhiteSpace(text))
+                    return;
+
+                var now = DateTime.UtcNow;
+                if (text == _lastScan && (now - _lastScanTime).TotalMilliseconds < 200)
+                    return;
+
+                _lastScan = text;
+                _lastScanTime = now;
+
+                if (DataContext is VistaSalidaFinalViewModel vm)
+                    vm.SubmitPass(text, "qr");
+
+                e.Handled = true;
+            }
+            else
+            {
+                char c = KeyToChar(e.Key);
+                if (c != '\0')
+                {
+                    _qrBuffer.Append(c);
+                    _qrTimer.Stop();
+                    _qrTimer.Start();
+                }
+            }
+        }
+
+        private void QrTimer_Tick(object sender, EventArgs e)
+        {
+            _qrTimer.Stop();
+            _qrBuffer.Clear();
+        }
+
+        private static char KeyToChar(Key key)
+        {
+            if (key >= Key.D0 && key <= Key.D9)
+                return (char)('0' + (key - Key.D0));
+            if (key >= Key.NumPad0 && key <= Key.NumPad9)
+                return (char)('0' + (key - Key.NumPad0));
+            if (key >= Key.A && key <= Key.Z)
+                return (char)('A' + (key - Key.A));
+            return '\0';
         }
     }
 }


### PR DESCRIPTION
## Summary
- replicate QR scan handling from VistaEntradaSalida in final exit view
- auto-process and print when a pass is read in VistaSalidaFinal

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68a344e06c9c833090375b26845ca4b8