### PR TITLE
Sync state panel with salida mode transitions

### DIFF
--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
@@ -164,6 +164,12 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         {
             await Task.Delay(5000);
             EstadoProceso = EstadoProcesoEnum.EnEspera;
+
+            // Reiniciamos el panel de estados para que el próximo proceso
+            // comience desde "Pase".  Al utilizar el mismo método que procesa
+            // los cambios de estado (SetEstadoDesdeCodigo) garantizamos que la
+            // propiedad de notificación se dispare y la interfaz se actualice.
+            SetEstadoDesdeCodigo("I");
         }
 
         private void ObtenerQuiosco()

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaSalidaFinalViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaSalidaFinalViewModel.cs
@@ -129,6 +129,14 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
 
             };
             _mainViewModel.EstadoProceso = EstadoProcesoEnum.SalidaRegistrada;
+
+            // Al registrar la salida, el panel de estados de la ventana principal
+            // debe reflejar que se ha alcanzado el paso "Ticket". En modo salida
+            // no existe un código propio para este paso, por lo que notificamos
+            // explícitamente al MainWindowViewModel utilizando el mismo mecanismo
+            // que en la vista de entrada/salida.
+            EstadoPanelEvents.RaiseEstadoCodigoCambiado("P");
+
             Imprimir();
             _ = _mainViewModel.ReiniciarDespuesDeSalidaAsync();
         }


### PR DESCRIPTION
## Summary
- Notify main window to highlight Ticket step when processing salida.
- Reset state panel to Pase after finalizing a salida.

## Testing
- ❌ `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` (dotnet not installed)
- ⚠️ `apt-get update` (403 Forbidden: repository not signed)


------
https://chatgpt.com/codex/tasks/task_e_68a36000696c83308a15c7168ba8782a