### PR TITLE
Clear exit info when pass resets

### DIFF
--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaSalidaFinalViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaSalidaFinalViewModel.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using System.Text.RegularExpressions;
+using System.ComponentModel;
 using ControlesAccesoQR;
 using ControlesAccesoQR.accesoDatos;
 using ControlesAccesoQR.Models;
@@ -49,12 +50,35 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         public VistaSalidaFinalViewModel(MainWindowViewModel mainViewModel)
         {
             _mainViewModel = mainViewModel;
+            _mainViewModel.PropertyChanged += MainViewModelOnPropertyChanged;
+
             SubmitPassCommand = new RelayCommand(() => SubmitPass(NumeroPaseSalida, "manual"));
             ProcesarSalidaCommand = new AsyncRelayCommand(ProcesarSalidaAsync);
             ImprimirCommand = new RelayCommand(Imprimir, PuedeImprimir);
 
             Contenedores.Add("CONT-001");
             Contenedores.Add("CONT-002");
+        }
+
+        private void MainViewModelOnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(MainWindowViewModel.EstadoProceso) &&
+                _mainViewModel.EstadoProceso == EstadoProcesoEnum.EnEspera)
+            {
+                LimpiarCampos();
+            }
+        }
+
+        private void LimpiarCampos()
+        {
+            Nombre = string.Empty;
+            Empresa = string.Empty;
+            Patente = string.Empty;
+            HoraSalida = string.Empty;
+            NumeroPaseSalida = string.Empty;
+            FechaSalida = null;
+            SalidaRegistrada = false;
+            MensajeError = string.Empty;
         }
 
         private async Task ProcesarSalidaAsync()


### PR DESCRIPTION
## Summary
- reset exit data bindings when main process returns to waiting state
- ensure pass view clears fields and hides panel after restart

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found: dotnet)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68a3632e1fa48330b72e2496a9bfca07