### PR TITLE
Centralize pass number handling

### DIFF
--- a/ControlesAccesoQR/AsyncRelayCommand.cs
+++ b/ControlesAccesoQR/AsyncRelayCommand.cs
@@ -6,11 +6,18 @@ namespace ControlesAccesoQR
 {
     public class AsyncRelayCommand : ICommand
     {
-        private readonly Func<Task> _execute;
-        private readonly Func<bool> _canExecute;
+        private readonly Func<object, Task> _execute;
+        private readonly Func<object, bool> _canExecute;
         private bool _isExecuting;
 
         public AsyncRelayCommand(Func<Task> execute, Func<bool> canExecute = null)
+        {
+            if (execute == null) throw new ArgumentNullException(nameof(execute));
+            _execute = _ => execute();
+            _canExecute = canExecute != null ? new Func<object, bool>(_ => canExecute()) : null;
+        }
+
+        public AsyncRelayCommand(Func<object, Task> execute, Func<object, bool> canExecute = null)
         {
             _execute = execute ?? throw new ArgumentNullException(nameof(execute));
             _canExecute = canExecute;
@@ -18,7 +25,7 @@ namespace ControlesAccesoQR
 
         public bool CanExecute(object parameter)
         {
-            return !_isExecuting && (_canExecute?.Invoke() ?? true);
+            return !_isExecuting && (_canExecute?.Invoke(parameter) ?? true);
         }
 
         public event EventHandler CanExecuteChanged;
@@ -32,7 +39,7 @@ namespace ControlesAccesoQR
             {
                 _isExecuting = true;
                 RaiseCanExecuteChanged();
-                await _execute();
+                await _execute(parameter);
             }
             finally
             {

--- a/ControlesAccesoQR/UserControls/TecladoNumerico.xaml.cs
+++ b/ControlesAccesoQR/UserControls/TecladoNumerico.xaml.cs
@@ -30,6 +30,15 @@ namespace ControlesAccesoQR.UserControls
             set => SetValue(ComandoOkProperty, value);
         }
 
+        public static readonly DependencyProperty ComandoOkParameterProperty =
+            DependencyProperty.Register(nameof(ComandoOkParameter), typeof(object), typeof(TecladoNumerico), new PropertyMetadata(null));
+
+        public object ComandoOkParameter
+        {
+            get => GetValue(ComandoOkParameterProperty);
+            set => SetValue(ComandoOkParameterProperty, value);
+        }
+
         private void Numero_Click(object sender, RoutedEventArgs e)
         {
             if (sender is Button btn)
@@ -54,8 +63,9 @@ namespace ControlesAccesoQR.UserControls
 
         private void Ok_Click(object sender, RoutedEventArgs e)
         {
-            if (ComandoOk?.CanExecute(null) == true)
-                ComandoOk.Execute(null);
+            var param = ComandoOkParameter ?? Text;
+            if (ComandoOk?.CanExecute(param) == true)
+                ComandoOk.Execute(param);
             InputTextBox.Focus();
         }
 
@@ -63,8 +73,9 @@ namespace ControlesAccesoQR.UserControls
         {
             if (e.Key == Key.Enter)
             {
-                if (ComandoOk?.CanExecute(null) == true)
-                    ComandoOk.Execute(null);
+                var param = ComandoOkParameter ?? Text;
+                if (ComandoOk?.CanExecute(param) == true)
+                    ComandoOk.Execute(param);
                 e.Handled = true;
             }
         }

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using System.Windows;
 using ControlesAccesoQR;
 using System.Windows.Input;
-using System.Text.RegularExpressions;
 using QRCoder;
 using RECEPTIO.CapaPresentacion.UI.Interfaces.RFID;
 using RECEPTIO.CapaPresentacion.UI.MVVM;
@@ -35,7 +34,6 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         private string _qrImagePath;
         private string _codigoQR;
         private bool _isBusy;
-        private string _numeroPaseEscaneado;
         private string _rfidMensaje;
         private string _estadoActual;
         private DateTime? _ultimaActualizacion;
@@ -43,16 +41,13 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         private string _salida;
         private string _chofer;
         private string _mensajeError;
-        private bool _isProcessing;
-        private string _ultimoQRProcesado;
+        private int _isProcessing;
+        private string _ultimoCodigoProcesado;
         private CancellationTokenSource _debounceCts;
         private readonly TimeSpan _debounceDelay = TimeSpan.FromMilliseconds(300);
-        private CancellationTokenSource _cts;
         private bool _lectorSuscrito;
         private string _numeroPase;
         public bool HabilitarAutoPorLectorQR { get; set; }
-
-        private static readonly Regex _rxQR = new Regex(@"^[A-Za-z0-9\-\:_/\.]{6,40}$", RegexOptions.Compiled);
 
         private readonly PasePuertaDataAccess _dataAccess = new PasePuertaDataAccess();
         private readonly IEstadoService _estadoService = new EstadoService();
@@ -88,7 +83,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
 
                 if (!HabilitarAutoPorLectorQR)
                 {
-                    ProcesarQRCommand?.RaiseCanExecuteChanged();
+                    ProcesarCommand?.RaiseCanExecuteChanged();
                     return;
                 }
 
@@ -101,11 +96,14 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
             get => _numeroPase;
             set
             {
-                var cleaned = (value ?? string.Empty).Trim();
+                var cleaned = (value ?? string.Empty)
+                    .Replace("\r", string.Empty)
+                    .Replace("\n", string.Empty)
+                    .Trim();
                 if (_numeroPase == cleaned) return;
                 _numeroPase = cleaned;
                 OnPropertyChanged(nameof(NumeroPase));
-                ProcesarQRCommand?.RaiseCanExecuteChanged();
+                CommandManager.InvalidateRequerySuggested();
             }
         }
 
@@ -120,29 +118,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
             }
         }
 
-        public bool IsProcessing
-        {
-            get => _isProcessing;
-            private set
-            {
-                if (_isProcessing == value) return;
-                _isProcessing = value;
-                OnPropertyChanged(nameof(IsProcessing));
-                ProcesarQRCommand?.RaiseCanExecuteChanged();
-            }
-        }
-
-        public string NumeroPaseEscaneado
-        {
-            get => _numeroPaseEscaneado;
-            private set
-            {
-                if (_numeroPaseEscaneado == value)
-                    return;
-                _numeroPaseEscaneado = value;
-                OnPropertyChanged(nameof(NumeroPaseEscaneado));
-            }
-        }
+        public bool IsProcessing => _isProcessing != 0;
 
         public string IdentificadorDeTrabajo => CodigoQR;
 
@@ -164,7 +140,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
             private set { _ultimaActualizacion = value; OnPropertyChanged(nameof(UltimaActualizacion)); }
         }
 
-        public AsyncRelayCommand ProcesarQRCommand { get; }
+        public AsyncRelayCommand ProcesarCommand { get; }
 
         public VistaEntradaSalidaViewModel(MainWindowViewModel mainViewModel)
         {
@@ -178,46 +154,37 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
                 _lectorSuscrito = true;
             }
 
-            ProcesarQRCommand = new AsyncRelayCommand(
-                () => ProcesarEntradaSalidaAsync(CodigoQR),
-                () => !IsProcessing && (!string.IsNullOrWhiteSpace(CodigoQR) || !string.IsNullOrWhiteSpace(NumeroPase)));
+            ProcesarCommand = new AsyncRelayCommand(
+                async param =>
+                {
+                    var texto = (param as string) ?? NumeroPase;
+                    await ProcesarEntradaSalidaAsync(texto);
+                },
+                param => !IsProcessing && !string.IsNullOrWhiteSpace((param as string) ?? NumeroPase));
         }
 
 
-        private async Task ProcesarEntradaSalidaAsync(string qrDesdeUI = null)
+        private async Task ProcesarEntradaSalidaAsync(string valor = null)
         {
-            if (IsProcessing) return;
-
-            var qr = (qrDesdeUI ?? CodigoQR ?? NumeroPase ?? string.Empty)
-                .Replace("\r", string.Empty)
-                .Replace("\n", string.Empty)
-                .Trim();
-
-            if (string.IsNullOrWhiteSpace(qr))
-            {
-                MensajeError = "Ingrese el código o número de pase.";
-                return;
-            }
-
-            if (!_rxQR.IsMatch(qr))
-            {
-                MensajeError = "El QR no tiene un formato válido.";
-                return;
-            }
-
-            if (string.Equals(_ultimoQRProcesado, qr, StringComparison.Ordinal))
-                return;
+            if (Interlocked.Exchange(ref _isProcessing, 1) == 1) return;
+            OnPropertyChanged(nameof(IsProcessing));
 
             try
             {
-                IsProcessing = true;
                 MensajeError = string.Empty;
 
-                _cts?.Cancel();
-                _cts = new CancellationTokenSource();
-                var ct = _cts.Token;
+                var codigo = (valor ?? NumeroPase ?? string.Empty).Trim();
 
-                var datos = _dataAccess.ObtenerChoferEmpresaPorPaseSalida(qr);
+                if (string.IsNullOrWhiteSpace(codigo))
+                {
+                    MensajeError = "Ingrese el código o número de pase.";
+                    return;
+                }
+
+                if (string.Equals(_ultimoCodigoProcesado, codigo, StringComparison.Ordinal))
+                    return;
+
+                var datos = _dataAccess.ObtenerChoferEmpresaPorPaseSalida(codigo);
                 if (datos == null)
                 {
                     MensajeError = "Código inválido.";
@@ -230,7 +197,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
                 ChoferID = datos.ChoferID;
                 Chofer = datos.ChoferNombre;
 
-                var resultado = _dataAccess.ActualizarFechaLlegada(qr);
+                var resultado = _dataAccess.ActualizarFechaLlegada(codigo);
                 if (resultado == null)
                 {
                     MensajeError = "No se pudo registrar.";
@@ -239,11 +206,14 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
 
                 HoraLlegada = resultado.FechaHoraLlegada;
                 Fecha = resultado.FechaHoraLlegada;
-                NumeroPaseEscaneado = qr;
 
-                CodigoQR = resultado.PasePuertaID.ToString();
+                NumeroPase = codigo;
 
-                if (!await ActualizarEstadoAsync("I", ct))
+                var idPase = resultado.PasePuertaID.ToString();
+                if (!string.Equals(CodigoQR, idPase, StringComparison.Ordinal))
+                    CodigoQR = idPase;
+
+                if (!await ActualizarEstadoAsync("I", default))
                     return;
 
                 IngresoRealizado = true;
@@ -253,23 +223,19 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
                     NombreChofer = Nombre,
                     Placa = Patente,
                     FechaHoraLlegada = HoraLlegada,
-                    NumeroPase = CodigoQR,
+                    NumeroPase = NumeroPase,
                     Estado = EstadoProcesoTipo.EnEspera,
                 };
 
-                await ImprimirAsync(qr);
+                await ImprimirAsync(codigo);
 
-                _ultimoQRProcesado = qr;
-            }
-            catch (OperationCanceledException) { }
-            catch (Exception ex)
-            {
-                MensajeError = $"Error al procesar el QR: {ex.Message}";
+                _ultimoCodigoProcesado = codigo;
             }
             finally
             {
-                IsProcessing = false;
-                ProcesarQRCommand?.RaiseCanExecuteChanged();
+                Interlocked.Exchange(ref _isProcessing, 0);
+                OnPropertyChanged(nameof(IsProcessing));
+                CommandManager.InvalidateRequerySuggested();
             }
         }
 

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
@@ -55,8 +55,9 @@
                  StretchDirection="DownOnly"
                  MaxWidth="480"
                  Margin="0,0,0,10">
-            <uc:TecladoNumerico Text="{Binding NumeroPase, Mode=TwoWay}"
-                                ComandoOk="{Binding ProcesarQRCommand}"
+            <uc:TecladoNumerico Text="{Binding NumeroPase, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                ComandoOk="{Binding ProcesarCommand}"
+                                ComandoOkParameter="{Binding NumeroPase}"
                                 Width="420" />
         </Viewbox>
 
@@ -71,8 +72,8 @@
                  MaxLines="1"
                  SpellCheck.IsEnabled="False"
                  ToolTip="Escanee el QR o digite el número">
-            <TextBox.InputBindings>
-                <KeyBinding Key="Enter" Command="{Binding ProcesarQRCommand}" />
+                 <TextBox.InputBindings>
+                <KeyBinding Key="Enter" Command="{Binding ProcesarCommand}" CommandParameter="{Binding Text, ElementName=txtQR}" />
             </TextBox.InputBindings>
         </TextBox>
 
@@ -84,7 +85,7 @@
                 HorizontalAlignment="Center"
                 Margin="0,0,0,10"
                 IsDefault="True"
-                Command="{Binding ProcesarQRCommand}" />
+                Command="{Binding ProcesarCommand}" CommandParameter="{Binding Text, ElementName=txtQR}" />
 
         <!-- Información adicional -->
         <StackPanel Grid.Row="5" Grid.Column="1"


### PR DESCRIPTION
## Summary
- sanitize and notify NumeroPase immediately
- send TecladoNumerico text as command parameter
- process pass numbers directly instead of relying on scanned fields

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository signatures missing)*

------
https://chatgpt.com/codex/tasks/task_e_68adddbf0cfc8330856b305973d58299