### PR TITLE
Add dedicated processing command methods

### DIFF
--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
@@ -172,10 +172,33 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
             }
 
             ProcesarCommand = new RelayCommand(
-                async () => await ProcesarEntradaSalidaAsync(),
-                () => !IsProcessing && (!string.IsNullOrWhiteSpace(NumeroPase) || !string.IsNullOrWhiteSpace(CodigoQR) || !string.IsNullOrWhiteSpace(NumeroPaseEscaneado)));
+                OnProcesar,
+                CanProcesar);
         }
 
+
+        private bool CanProcesar()
+        {
+            return Interlocked.CompareExchange(ref _isProcessing, 0, 0) == 0 &&
+                   (!string.IsNullOrWhiteSpace(NumeroPase) ||
+                    !string.IsNullOrWhiteSpace(CodigoQR) ||
+                    !string.IsNullOrWhiteSpace(NumeroPaseEscaneado));
+        }
+
+        private async void OnProcesar()
+        {
+            try
+            {
+                var input = NumeroPase;
+                NumeroPase = input?.Trim();
+                await ProcesarEntradaSalidaAsync();
+            }
+            finally
+            {
+                NumeroPase = string.Empty;
+                CommandManager.InvalidateRequerySuggested();
+            }
+        }
 
         private async Task ProcesarEntradaSalidaAsync()
         {


### PR DESCRIPTION
## Summary
- Add `CanProcesar` and `OnProcesar` methods to `VistaEntradaSalidaViewModel` for clearer command handling and reentrancy check

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*
- `apt-get update` *(fails: 403 Repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ade4911e7083308fac56f5367dd43f