### PR TITLE
Inyectar VistaEntradaSalidaViewModel con MainWindowViewModel y enfocar QrInput

### DIFF
--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml
@@ -61,7 +61,7 @@
         </Viewbox>
 
         <!-- Entrada QR -->
-        <TextBox x:Name="txtQR"
+        <TextBox x:Name="QrInput"
                  Grid.Row="3" Grid.ColumnSpan="2"
                  Text="{Binding CodigoQR, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
                  HorizontalAlignment="Stretch"

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
@@ -1,13 +1,15 @@
 using System.Windows.Controls;
+using ControlesAccesoQR.ViewModels.ControlesAccesoQR;
 
 namespace ControlesAccesoQR.Views.ControlesAccesoQR
 {
     public partial class VistaEntradaSalida : UserControl
     {
-        public VistaEntradaSalida()
+        public VistaEntradaSalida(MainWindowViewModel mainViewModel)
         {
             InitializeComponent();
-            Loaded += (_, __) => { txtQR?.Focus(); };
+            DataContext = new VistaEntradaSalidaViewModel(mainViewModel);
+            Loaded += (_, __) => { QrInput?.Focus(); };
         }
     }
 }


### PR DESCRIPTION
## Summary
- Inyecta MainWindowViewModel en la vista de entrada/salida y crea VistaEntradaSalidaViewModel como DataContext
- Renombra el campo de texto a QrInput y asegura que reciba el foco al cargarse

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(falla: bash: command not found: dotnet)*
- `apt-get update` *(falla: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ade81c1cfc83309982928bacb05692