### PR TITLE
feat: restore kiosk state panel

### DIFF
--- a/ControlesAccesoQR/Converters/EqualityConverter.cs
+++ b/ControlesAccesoQR/Converters/EqualityConverter.cs
@@ -10,7 +10,18 @@ namespace ControlesAccesoQR.Converters
         {
             if (values == null || values.Length < 2)
                 return false;
-            return Equals(values[0], values[1]);
+
+            var x = values[0];
+            var y = values[1];
+
+            if (x == null || y == null)
+                return x == y;
+
+            // Allow string comparison without casing sensitivity
+            if (x is string s1 && y is string s2)
+                return string.Equals(s1, s2, StringComparison.OrdinalIgnoreCase);
+
+            return Equals(x, y);
         }
 
         public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)

--- a/ControlesAccesoQR/MainWindow.xaml
+++ b/ControlesAccesoQR/MainWindow.xaml
@@ -23,6 +23,7 @@
         <conv:EqualityConverter x:Key="EqualityConverter" />
     </Window.Resources>
 
+    <!-- UI de Estados y Kiosco -->
     <Grid Background="{StaticResource StandardBackground}">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="7*" />

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
@@ -46,31 +46,33 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
             EstadoPanel.Ticket
         };
 
-        private IEnumerable<EstadoPanel> _estados = _todosLosEstados;
+        private readonly ObservableCollection<EstadoPanel> _estados = new ObservableCollection<EstadoPanel>(_todosLosEstados);
 
-        public IEnumerable<EstadoPanel> Estados
-        {
-            get => _estados;
-            private set
-            {
-                _estados = value;
-                OnPropertyChanged(nameof(Estados));
-            }
-        }
+        public ObservableCollection<EstadoPanel> Estados => _estados;
 
         public string NumeroKiosco
         {
             get => _numeroKiosco;
-            private set { _numeroKiosco = value; OnPropertyChanged(nameof(NumeroKiosco)); }
+            set { _numeroKiosco = value; OnPropertyChanged(nameof(NumeroKiosco)); }
         }
 
         public bool IsKioskEntrada { get; private set; }
 
         public string TipoKioscoTexto => IsKioskEntrada ? "Entrada" : "Salida";
 
-        public string KioscoTitulo => "Kiosco";
+        private string _kioscoTitulo;
+        public string KioscoTitulo
+        {
+            get => _kioscoTitulo;
+            set { _kioscoTitulo = value; OnPropertyChanged(nameof(KioscoTitulo)); }
+        }
 
-        public ImageSource KioscoLogo { get; } = new BitmapImage(new Uri("pack://application:,,,/ControlesAccesoQR;component/Assets/Logo.png"));
+        private ImageSource _kioscoLogo;
+        public ImageSource KioscoLogo
+        {
+            get => _kioscoLogo;
+            set { _kioscoLogo = value; OnPropertyChanged(nameof(KioscoLogo)); }
+        }
 
         public EstadoPanel EstadoActual
         {
@@ -119,6 +121,9 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         {
             _frame = frame;
 
+            KioscoTitulo = "Kiosco";
+            KioscoLogo = new BitmapImage(new Uri("pack://application:,,,/ControlesAccesoQR;component/Assets/Logo.png"));
+
             _reloj.Tick += (s, e) => FechaHora = DateTime.Now.ToString("dd/MM/yyyy HH:mm");
             _reloj.Start();
 
@@ -129,7 +134,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
 
         public void MostrarEntradaSalida()
         {
-            Estados = _todosLosEstados;
+            SetEstados(_todosLosEstados);
             _frame.Navigate(new VistaEntradaSalida(this));
         }
 
@@ -138,7 +143,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
             // La salida final sólo requiere visualizar los pasos "Pase" y "Ticket"
             // por lo que filtramos el panel de estados para mostrar únicamente
             // dichos elementos en la interfaz del kiosco.
-            Estados = FiltrarEstadosPorCodigos(new[] { "Pase", "Ticket" });
+            SetEstados(FiltrarEstadosPorCodigos(new[] { "Pase", "Ticket" }));
 
             // VistaSalidaFinalViewModel contiene toda la lógica específica de
             // salida, incluyendo las llamadas a los procedimientos almacenados
@@ -158,6 +163,13 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         {
             var permitidos = new HashSet<string>(codigos, StringComparer.OrdinalIgnoreCase);
             return _todosLosEstados.Where(e => permitidos.Contains(e.ToString()));
+        }
+
+        private void SetEstados(IEnumerable<EstadoPanel> estados)
+        {
+            Estados.Clear();
+            foreach (var estado in estados)
+                Estados.Add(estado);
         }
 
         public async Task ReiniciarDespuesDeSalidaAsync()


### PR DESCRIPTION
## Summary
- add multi-value EqualityConverter for object comparison in bindings
- expose kiosk details and state collection through MainWindowViewModel
- document Estados + Kiosco UI block in MainWindow

## Testing
- `dotnet build ControlesAccesoQR.csproj -c Release` *(fails: command not found)*
- `msbuild ControlesAccesoQR.csproj /p:Configuration=Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adfb6d171c8330b600916931ebbc04