### PR TITLE
Restore full entry pipeline with fingerprint and RFID stages

### DIFF
--- a/ControlesAccesoQR/ControlesAccesoQR.csproj
+++ b/ControlesAccesoQR/ControlesAccesoQR.csproj
@@ -170,6 +170,11 @@
     <Compile Include="Servicios\EstadoService.cs" />
     <Compile Include="Servicios\EstadoPanelEvents.cs" />
     <Compile Include="Servicios\PrintService.cs" />
+    <Compile Include="Servicios\IPrintService.cs" />
+    <Compile Include="Servicios\IHuellaService.cs" />
+    <Compile Include="Servicios\HuellaService.cs" />
+    <Compile Include="Servicios\IRfidReader.cs" />
+    <Compile Include="Servicios\RfidReader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/ControlesAccesoQR/Estados/EstadoProceso.cs
+++ b/ControlesAccesoQR/Estados/EstadoProceso.cs
@@ -5,6 +5,7 @@ namespace ControlesAccesoQR.Estados
         Pase,
         Huella,
         Tag,
-        Ticket
+        Ticket,
+        EnEspera
     }
 }

--- a/ControlesAccesoQR/Servicios/EstadoService.cs
+++ b/ControlesAccesoQR/Servicios/EstadoService.cs
@@ -2,6 +2,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using ControlesAccesoQR.accesoDatos;
 using ControlesAccesoQR.Models;
+using ControlesAccesoQR.Estados;
 
 namespace ControlesAccesoQR.Servicios
 {
@@ -17,6 +18,11 @@ namespace ControlesAccesoQR.Servicios
         public Task<ActualizarEstadoResult> ActualizarAsync(string numeroPase, string estado, CancellationToken ct = default)
         {
             return _dataAccess.ActualizarEstadoAsync(numeroPase, estado, ct);
+        }
+
+        public void Set(EstadoProceso estado)
+        {
+            EstadoPanelEvents.RaiseEstadoCodigoCambiado(estado.ToString());
         }
     }
 }

--- a/ControlesAccesoQR/Servicios/HuellaService.cs
+++ b/ControlesAccesoQR/Servicios/HuellaService.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using RECEPTIO.CapaPresentacion.UI.Biometrico;
+using RECEPTIO.CapaPresentacion.UI.Interfaces.Biometrico;
+
+namespace ControlesAccesoQR.Servicios
+{
+    public class HuellaService : IHuellaService
+    {
+        private readonly IBiometrico _biometrico;
+
+        public HuellaService()
+        {
+            _biometrico = new Biometrico();
+        }
+
+        public Task<bool> CapturarYValidarAsync(string choferId)
+        {
+            if (string.IsNullOrWhiteSpace(choferId))
+                return Task.FromResult(false);
+
+            if (DevBypass.IsDevKiosk)
+                return Task.FromResult(true);
+
+            return Task.Run(() =>
+            {
+                var resultado = _biometrico.ProcesoHuella(choferId);
+                return !string.IsNullOrEmpty(resultado) && resultado.Contains(choferId);
+            });
+        }
+    }
+}

--- a/ControlesAccesoQR/Servicios/IEstadoService.cs
+++ b/ControlesAccesoQR/Servicios/IEstadoService.cs
@@ -1,11 +1,13 @@
 using System.Threading;
 using System.Threading.Tasks;
 using ControlesAccesoQR.Models;
+using ControlesAccesoQR.Estados;
 
 namespace ControlesAccesoQR.Servicios
 {
     public interface IEstadoService
     {
         Task<ActualizarEstadoResult> ActualizarAsync(string numeroPase, string estado, CancellationToken ct = default);
+        void Set(EstadoProceso estado);
     }
 }

--- a/ControlesAccesoQR/Servicios/IHuellaService.cs
+++ b/ControlesAccesoQR/Servicios/IHuellaService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace ControlesAccesoQR.Servicios
+{
+    public interface IHuellaService
+    {
+        Task<bool> CapturarYValidarAsync(string choferId);
+    }
+}

--- a/ControlesAccesoQR/Servicios/IPrintService.cs
+++ b/ControlesAccesoQR/Servicios/IPrintService.cs
@@ -1,0 +1,7 @@
+namespace ControlesAccesoQR.Servicios
+{
+    public interface IPrintService
+    {
+        void Print(string contenido);
+    }
+}

--- a/ControlesAccesoQR/Servicios/IRfidReader.cs
+++ b/ControlesAccesoQR/Servicios/IRfidReader.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ControlesAccesoQR.Servicios
+{
+    public interface IRfidReader
+    {
+        Task<string> LeerAsync(CancellationToken ct);
+    }
+}

--- a/ControlesAccesoQR/Servicios/PrintService.cs
+++ b/ControlesAccesoQR/Servicios/PrintService.cs
@@ -2,7 +2,7 @@ using System.Diagnostics;
 
 namespace ControlesAccesoQR.Servicios
 {
-    public class PrintService
+    public class PrintService : IPrintService
     {
         public void Print(string contenido)
         {

--- a/ControlesAccesoQR/Servicios/RfidReader.cs
+++ b/ControlesAccesoQR/Servicios/RfidReader.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using RECEPTIO.CapaPresentacion.UI.Interfaces.RFID;
+using Spring.Context.Support;
+
+namespace ControlesAccesoQR.Servicios
+{
+    public class RfidReader : IRfidReader
+    {
+        public async Task<string> LeerAsync(CancellationToken ct)
+        {
+            if (DevBypass.IsDevKiosk)
+                return "SIMULADO-0001";
+
+            IAntena antena = null;
+            try
+            {
+                var ctx = new XmlApplicationContext("~/Springs/SpringAntena.xml");
+                antena = (IAntena)ctx["AdministradorAntena"];
+                if (!antena.ConectarAntena())
+                    return null;
+
+                antena.IniciarLectura();
+                await Task.Delay(1000, ct);
+                List<string> tags = antena.ObtenerTagsLeidos();
+                return tags != null && tags.Count > 0 ? tags[0] : null;
+            }
+            finally
+            {
+                antena?.TerminarLectura();
+                antena?.DesconectarAntena();
+                antena?.Dispose();
+            }
+        }
+    }
+}

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Data.SqlClient;
@@ -18,8 +19,10 @@ using ControlesAccesoQR.accesoDatos;
 using ControlesAccesoQR.Models;
 using ControlesAccesoQR.Impresion;
 using ControlesAccesoQR.Servicios;
+using ControlesAccesoQR.Estados;
 
 using EstadoProcesoTipo = ControlesAccesoQR.Models.EstadoProceso;
+using EstadoProcesoEnum = ControlesAccesoQR.Estados.EstadoProceso;
 
 
 namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
@@ -35,7 +38,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         private string _codigoQR;
         private bool _isBusy;
         private string _rfidMensaje;
-        private string _estadoActual;
+        private string _estadoActualCodigo;
         private DateTime? _ultimaActualizacion;
         private DateTime? _fecha;
         private string _salida;
@@ -49,8 +52,11 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         private string _numeroPase;
         public bool HabilitarAutoPorLectorQR { get; set; }
 
-        private readonly PasePuertaDataAccess _dataAccess = new PasePuertaDataAccess();
-        private readonly IEstadoService _estadoService = new EstadoService();
+        private readonly PasePuertaDataAccess _dataAccess;
+        private readonly IEstadoService _estadoService;
+        private readonly IHuellaService _huellaService;
+        private readonly IRfidReader _rfidReader;
+        private readonly IPrintService _printService;
         private readonly MainWindowViewModel _mainViewModel;
 
         public MainWindowViewModel MainViewModel => _mainViewModel;
@@ -145,10 +151,10 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
             private set { _rfidMensaje = value; OnPropertyChanged(nameof(RfidMensaje)); }
         }
 
-        public string EstadoActual
+        public string EstadoActualCodigo
         {
-            get => _estadoActual;
-            private set { _estadoActual = value; OnPropertyChanged(nameof(EstadoActual)); }
+            get => _estadoActualCodigo;
+            private set { _estadoActualCodigo = value; OnPropertyChanged(nameof(EstadoActualCodigo)); }
         }
 
         public DateTime? UltimaActualizacion
@@ -157,11 +163,41 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
             private set { _ultimaActualizacion = value; OnPropertyChanged(nameof(UltimaActualizacion)); }
         }
 
-        public ICommand ProcesarCommand { get; }
-
-        public VistaEntradaSalidaViewModel(MainWindowViewModel mainViewModel)
+        public ObservableCollection<EstadoProcesoEnum> Estados { get; } = new ObservableCollection<EstadoProcesoEnum>
         {
+            EstadoProcesoEnum.Pase,
+            EstadoProcesoEnum.Huella,
+            EstadoProcesoEnum.Tag,
+            EstadoProcesoEnum.Ticket
+        };
+
+        private EstadoProcesoEnum _estadoActual;
+        public EstadoProcesoEnum EstadoActual
+        {
+            get => _estadoActual;
+            set { _estadoActual = value; OnPropertyChanged(); _estadoService?.Set(value); }
+        }
+
+        public ICommand ProcesarCommand { get; }
+        public ICommand CapturarHuellaCommand { get; }
+        public ICommand LeerRfidCommand { get; }
+        public ICommand ImprimirCommand { get; }
+
+        public VistaEntradaSalidaViewModel(
+            PasePuertaDataAccess dataAccess,
+            IEstadoService estadoService,
+            IHuellaService huellaService,
+            IRfidReader rfidReader,
+            IPrintService printService,
+            MainWindowViewModel mainViewModel)
+        {
+            _dataAccess = dataAccess;
+            _estadoService = estadoService;
+            _huellaService = huellaService;
+            _rfidReader = rfidReader;
+            _printService = printService;
             _mainViewModel = mainViewModel;
+
             HabilitarAutoPorLectorQR = false;
 
             if (!_lectorSuscrito && HabilitarAutoPorLectorQR)
@@ -171,9 +207,12 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
                 _lectorSuscrito = true;
             }
 
-            ProcesarCommand = new RelayCommand(
-                OnProcesar,
-                CanProcesar);
+            ProcesarCommand = new RelayCommand(OnProcesar, CanProcesar);
+            CapturarHuellaCommand = new RelayCommand(async _ => await CapturarHuellaAsync(), _ => EstadoActual == EstadoProcesoEnum.Huella && _isProcessing == 0);
+            LeerRfidCommand = new RelayCommand(async _ => await LeerRfidAsync(), _ => EstadoActual == EstadoProcesoEnum.Tag && _isProcessing == 0);
+            ImprimirCommand = new RelayCommand(async _ => await ImprimirAsync(NumeroPase), _ => EstadoActual == EstadoProcesoEnum.Ticket && _isProcessing == 0);
+
+            EstadoActual = EstadoProcesoEnum.Pase;
         }
 
 
@@ -258,6 +297,62 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
                 if (!await ActualizarEstadoAsync("I", default))
                     return;
 
+                EstadoActual = EstadoProcesoEnum.Huella;
+
+                await CapturarHuellaAsync();
+
+                _ultimoCodigoProcesado = codigo;
+            }
+            finally
+            {
+                Interlocked.Exchange(ref _isProcessing, 0);
+                OnPropertyChanged(nameof(IsProcessing));
+                CommandManager.InvalidateRequerySuggested();
+            }
+        }
+
+        private async Task CapturarHuellaAsync()
+        {
+            if (EstadoActual != EstadoProcesoEnum.Huella) return;
+
+            try
+            {
+                MensajeError = string.Empty;
+                var ok = await _huellaService.CapturarYValidarAsync(ChoferID);
+                if (!ok)
+                {
+                    MensajeError = "No se pudo validar la huella. Intente nuevamente.";
+                    return;
+                }
+
+                EstadoActual = EstadoProcesoEnum.Tag;
+                await LeerRfidAsync();
+            }
+            catch (Exception ex)
+            {
+                MensajeError = $"Error de huella: {ex.Message}";
+            }
+        }
+
+        private async Task LeerRfidAsync()
+        {
+            if (EstadoActual != EstadoProcesoEnum.Tag) return;
+
+            try
+            {
+                MensajeError = string.Empty;
+                var tag = await _rfidReader.LeerAsync(CancellationToken.None);
+                if (string.IsNullOrWhiteSpace(tag))
+                {
+                    MensajeError = "No se leyó el TAG RFID. Acerque la tarjeta.";
+                    return;
+                }
+
+                _dataAccess.AsociarTagAPase(NumeroPase, tag);
+
+                EstadoActual = EstadoProcesoEnum.Ticket;
+
+                await ImprimirAsync(NumeroPase);
                 IngresoRealizado = true;
 
                 _mainViewModel.PaseActual = new PaseProcesoModel
@@ -268,16 +363,10 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
                     NumeroPase = NumeroPase,
                     Estado = EstadoProcesoTipo.EnEspera,
                 };
-
-                await ImprimirAsync(codigo);
-
-                _ultimoCodigoProcesado = codigo;
             }
-            finally
+            catch (Exception ex)
             {
-                Interlocked.Exchange(ref _isProcessing, 0);
-                OnPropertyChanged(nameof(IsProcessing));
-                CommandManager.InvalidateRequerySuggested();
+                MensajeError = $"Error RFID: {ex.Message}";
             }
         }
 
@@ -315,7 +404,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
                     return false;
                 }
 
-                EstadoActual = result.Estado;
+                EstadoActualCodigo = result.Estado;
                 CodigoQR = result.PasePuertaID.ToString();
                 UltimaActualizacion = result.FechaActualizacion;
                 EstadoPanelEvents.RaiseEstadoCodigoCambiado(result.Estado);
@@ -354,6 +443,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
 
             if (DevBypass.IsDevKiosk)
             {
+                _printService.Print("Impresión simulada");
                 MessageBox.Show("Impresión simulada (CGDE041)");
                 return;
             }
@@ -369,6 +459,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
             using (var ticket = new ImprimirTicketSalidaQr(codigo, datos))
             {
                 ticket.Imprimir();
+                _printService.Print(codigo);
             }
         }
 

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
@@ -1,5 +1,7 @@
 using System.Windows.Controls;
 using ControlesAccesoQR.ViewModels.ControlesAccesoQR;
+using ControlesAccesoQR.accesoDatos;
+using ControlesAccesoQR.Servicios;
 
 namespace ControlesAccesoQR.Views.ControlesAccesoQR
 {
@@ -8,7 +10,13 @@ namespace ControlesAccesoQR.Views.ControlesAccesoQR
         public VistaEntradaSalida(MainWindowViewModel mainViewModel)
         {
             InitializeComponent();
-            DataContext = new VistaEntradaSalidaViewModel(mainViewModel);
+            DataContext = new VistaEntradaSalidaViewModel(
+                new PasePuertaDataAccess(),
+                new EstadoService(),
+                new HuellaService(),
+                new RfidReader(),
+                new PrintService(),
+                mainViewModel);
             Loaded += (_, __) => { QrInput?.Focus(); };
         }
     }

--- a/ControlesAccesoQR/accesoDatos/PasePuertaDataAccess.cs
+++ b/ControlesAccesoQR/accesoDatos/PasePuertaDataAccess.cs
@@ -28,7 +28,7 @@ namespace ControlesAccesoQR.accesoDatos
             _extendedConnectionString = ConfigurationManager.ConnectionStrings["bill"].ConnectionString;
         }
 
-        // Obtiene ºs del chofer y empresa desde el SP de salida
+        // Obtiene Âºs del chofer y empresa desde el SP de salida
         public PasePuertaInfo ObtenerChoferEmpresaPorPaseSalida(string numeroPase)
         {
             PasePuertaInfo info = null;
@@ -320,6 +320,19 @@ namespace ControlesAccesoQR.accesoDatos
                 connection.Open();
                 var valor = command.ExecuteScalar();
                 return valor == null ? null : valor.ToString();
+            }
+        }
+
+        public void AsociarTagAPase(string numeroPase, string tag)
+        {
+            using (var connection = new SqlConnection(_connectionString))
+            using (var command = new SqlCommand("[vhs].[asociar_tag_a_pase]", connection))
+            {
+                command.CommandType = CommandType.StoredProcedure;
+                command.Parameters.AddWithValue("@NumeroPase", numeroPase);
+                command.Parameters.AddWithValue("@Tag", tag);
+                connection.Open();
+                command.ExecuteNonQuery();
             }
         }
     }


### PR DESCRIPTION
## Summary
- Extend VistaEntradaSalidaViewModel with Pase→Huella→Tag→Ticket state pipeline and new commands
- Introduce HuellaService and RfidReader services with interfaces for biometric and RFID capture
- Persist RFID tag association and update state notifications via expanded EstadoService

## Testing
- ❌ `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(dotnet: command not found)*
- ⚠️ `apt-get update` *(repository signatures unavailable; unable to install build tools)*

------
https://chatgpt.com/codex/tasks/task_e_68adfe77f36c83309bd62228867c8f18