### PR TITLE
Refactor EstadoProceso references to canonical enum

### DIFF
--- a/ControlesAccesoQR/Converters/SetContainsConverter.cs
+++ b/ControlesAccesoQR/Converters/SetContainsConverter.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Windows.Data;
-using ControlesAccesoQR.Estados;
+
+// Alias canónico
+using EstadoProcesoEnum = ControlesAccesoQR.Models.EstadoProceso;
 
 namespace ControlesAccesoQR.Converters
 {
@@ -13,7 +15,7 @@ namespace ControlesAccesoQR.Converters
             if (values == null || values.Length < 2)
                 return false;
 
-            if (values[0] is ISet<EstadoProceso> set && values[1] is EstadoProceso estado)
+            if (values[0] is ISet<EstadoProcesoEnum> set && values[1] is EstadoProcesoEnum estado)
                 return set.Contains(estado);
 
             return false;

--- a/ControlesAccesoQR/MainWindow.xaml
+++ b/ControlesAccesoQR/MainWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="ControlesAccesoQR.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:estados="clr-namespace:ControlesAccesoQR.Estados"
+        xmlns:estados="clr-namespace:ControlesAccesoQR.Models"
         xmlns:conv="clr-namespace:ControlesAccesoQR.Converters"
         Title="ControlesAccesoQR"
         WindowState="Maximized"

--- a/ControlesAccesoQR/Servicios/EstadoService.cs
+++ b/ControlesAccesoQR/Servicios/EstadoService.cs
@@ -2,7 +2,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using ControlesAccesoQR.accesoDatos;
 using ControlesAccesoQR.Models;
-using ControlesAccesoQR.Estados;
+
+// Alias canónico
+using EstadoProcesoEnum = ControlesAccesoQR.Models.EstadoProceso;
 
 namespace ControlesAccesoQR.Servicios
 {
@@ -20,7 +22,7 @@ namespace ControlesAccesoQR.Servicios
             return _dataAccess.ActualizarEstadoAsync(numeroPase, estado, ct);
         }
 
-        public void Set(EstadoProceso estado)
+        public void Set(EstadoProcesoEnum estado)
         {
             EstadoPanelEvents.RaiseEstadoCodigoCambiado(estado.ToString());
         }

--- a/ControlesAccesoQR/Servicios/IEstadoService.cs
+++ b/ControlesAccesoQR/Servicios/IEstadoService.cs
@@ -1,13 +1,15 @@
 using System.Threading;
 using System.Threading.Tasks;
 using ControlesAccesoQR.Models;
-using ControlesAccesoQR.Estados;
+
+// Alias canónico
+using EstadoProcesoEnum = ControlesAccesoQR.Models.EstadoProceso;
 
 namespace ControlesAccesoQR.Servicios
 {
     public interface IEstadoService
     {
         Task<ActualizarEstadoResult> ActualizarAsync(string numeroPase, string estado, CancellationToken ct = default);
-        void Set(EstadoProceso estado);
+        void Set(EstadoProcesoEnum estado);
     }
 }

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/MainWindowViewModel.cs
@@ -15,6 +15,7 @@ using ControlesAccesoQR.Views.ControlesAccesoQR;
 using ControlesAccesoQR.Servicios;
 
 using EstadoPanel = ControlesAccesoQR.Estados.EstadoProceso;
+// Alias canónico
 using EstadoProcesoEnum = ControlesAccesoQR.Models.EstadoProceso;
 
 using RECEPTIO.CapaPresentacion.UI.MVVM;

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
@@ -19,10 +19,8 @@ using ControlesAccesoQR.accesoDatos;
 using ControlesAccesoQR.Models;
 using ControlesAccesoQR.Impresion;
 using ControlesAccesoQR.Servicios;
-using ControlesAccesoQR.Estados;
-
-using EstadoProcesoTipo = ControlesAccesoQR.Models.EstadoProceso;
-using EstadoProcesoEnum = ControlesAccesoQR.Estados.EstadoProceso;
+// Alias canónico
+using EstadoProcesoEnum = ControlesAccesoQR.Models.EstadoProceso;
 
 
 namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
@@ -361,7 +359,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
                     Placa = Patente,
                     FechaHoraLlegada = HoraLlegada,
                     NumeroPase = NumeroPase,
-                    Estado = EstadoProcesoTipo.EnEspera,
+                    Estado = EstadoProcesoEnum.EnEspera,
                 };
             }
             catch (Exception ex)
@@ -540,7 +538,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
             if (resultado)
                 _mainViewModel.MostrarSalidaFinal();
             else
-                _mainViewModel.EstadoProceso = EstadoProcesoTipo.EnEspera;
+                _mainViewModel.EstadoProceso = EstadoProcesoEnum.EnEspera;
 
             return resultado;
         }

--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaSalidaFinalViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaSalidaFinalViewModel.cs
@@ -12,6 +12,7 @@ using ControlesAccesoQR.accesoDatos;
 using ControlesAccesoQR.Models;
 using ControlesAccesoQR.Servicios;
 using ControlesAccesoQR.Impresion;
+// Alias canónico
 using EstadoProcesoEnum = ControlesAccesoQR.Models.EstadoProceso;
 
 using RECEPTIO.CapaPresentacion.UI.MVVM;


### PR DESCRIPTION
## Summary
- use ControlesAccesoQR.Models.EstadoProceso via EstadoProcesoEnum alias
- update services, view models, converter, and XAML to remove ambiguous EstadoProceso reference
## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*
- `msbuild ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae01e696c08330bd92d115fa62da89