### PR TITLE
Improve RFID tag reading reliability

### DIFF
--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
@@ -391,22 +391,27 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
                     }
 
                     antena.IniciarLectura();
-                    await Task.Delay(1000);
-                    List<string> tags = antena.ObtenerTagsLeidos();
 
-                    if (tags == null || !tags.Any())
+                    var inicio = DateTime.UtcNow;
+                    var hayTags = false;
+                    while (DateTime.UtcNow - inicio < TimeSpan.FromSeconds(5) && !resultado)
                     {
-                        RfidMensaje = "No se leyó ningún tag";
+                        var tags = antena.ObtenerTagsLeidos();
+                        if (tags != null && tags.Any())
+                        {
+                            hayTags = true;
+                            if (tags.Contains(tagEsperado))
+                            {
+                                RfidMensaje = "Tag leído válido";
+                                resultado = true;
+                                break;
+                            }
+                        }
+                        await Task.Delay(500);
                     }
-                    else if (tags.Contains(tagEsperado))
-                    {
-                        RfidMensaje = "Tag leído válido";
-                        resultado = true;
-                    }
-                    else
-                    {
-                        RfidMensaje = "Tag leído no coincide";
-                    }
+
+                    if (!resultado)
+                        RfidMensaje = hayTags ? "Tag leído no coincide" : "No se leyó ningún tag";
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
## Summary
- improve RFID validation by polling tags every 500ms for up to 5 seconds and exiting early when the expected tag appears

## Testing
- ⚠️ `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(dotnet not installed; apt repositories unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c1bf3ddc8330ad2fc80bedd14f6b