### PR TITLE
Integrate RFID tag validation via WCF using PlacaCamion

### DIFF
--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/VistaEntradaSalidaViewModel.cs
@@ -225,7 +225,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
                 OnPropertyChanged(nameof(CodigoQR));
             }
 
-            if (!await ActualizarEstadoAsync("I"))
+            if (await ActualizarEstadoAsync("I") == null)
                 return;
 
             var qrText = $"{CodigoQR}|{resultado.FechaHoraLlegada:yyyy-MM-dd HH:mm:ss}";
@@ -260,10 +260,10 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         }
     }
 
-        public async Task<bool> ActualizarEstadoAsync(string estado, CancellationToken ct = default)
+        public async Task<ActualizarEstadoResult> ActualizarEstadoAsync(string estado, CancellationToken ct = default)
         {
             if (string.IsNullOrWhiteSpace(CodigoQR))
-                return false;
+                return null;
 
             try
             {
@@ -274,14 +274,15 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
                         MessageBox.Show("El pase no existe o el SP no devolvió filas");
                     else
                         Console.WriteLine("ActualizarEstadoAsync retornó null");
-                    return false;
+                    return null;
                 }
 
                 EstadoActual = result.Estado;
                 CodigoQR = result.PasePuertaID.ToString();
                 UltimaActualizacion = result.FechaActualizacion;
+                Patente = result.PlacaCamion;
                 EstadoPanelEvents.RaiseEstadoCodigoCambiado(result.Estado);
-                return true;
+                return result;
             }
             catch (SqlException ex)
             {
@@ -297,7 +298,7 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
                 else
                     Console.WriteLine(ex);
             }
-            return false;
+            return null;
         }
 
         private void ImprimirQr()
@@ -359,8 +360,9 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
         /// <summary>
         /// Ejecuta la validación del tag RFID de manera asíncrona.
         /// </summary>
+        /// <param name="tagEsperado">Tag obtenido desde el servicio para comparar.</param>
         /// <returns>true si el tag leído es válido.</returns>
-        public async Task<bool> ValidarRfidAsync()
+        public async Task<bool> ValidarRfidAsync(string tagEsperado)
         {
             bool resultado = false;
             IAntena antena = null;
@@ -375,7 +377,6 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
             {
                 try
                 {
-                    var tagEsperado = _dataAccess.ObtenerTagRfidPorPlaca(Patente);
                     if (string.IsNullOrWhiteSpace(tagEsperado))
                     {
                         RfidMensaje = "No existe tag en BD";

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
@@ -11,6 +11,7 @@ using ControlesAccesoQR;
 using ControlesAccesoQR.ViewModels.ControlesAccesoQR;
 using ControlesAccesoQR.Models;
 using EstadoProcesoTipo = ControlesAccesoQR.Models.EstadoProceso;
+using Transaction.ServicioTransaction;
 
 namespace ControlesAccesoQR.Views.ControlesAccesoQR
 {
@@ -176,12 +177,13 @@ namespace ControlesAccesoQR.Views.ControlesAccesoQR
                     if (DevBypass.IsDevKiosk)
                     {
                         await CompletarValidacionHuellaAsync(vm, "BYPASS CGDE041", 1);
-                        if (!await vm.ActualizarEstadoAsync("H"))
+                        var estadoH = await vm.ActualizarEstadoAsync("H");
+                        if (estadoH == null)
                             return;
                         MessageBox.Show("Huella validada");
 
                         await CompletarLecturaRfidAsync(vm, "TAG_SIMULADO");
-                        if (!await vm.ActualizarEstadoAsync("R"))
+                        if (await vm.ActualizarEstadoAsync("R") == null)
                             return;
                         MessageBox.Show("RFID detectado");
 
@@ -191,10 +193,18 @@ namespace ControlesAccesoQR.Views.ControlesAccesoQR
 
                     await CompletarValidacionHuellaAsync(vm, "VALIDACION AUTOMATICA", 1);
 
-                    if (!await vm.ActualizarEstadoAsync("H"))
+                    var resultadoH = await vm.ActualizarEstadoAsync("H");
+                    if (resultadoH == null)
                         return;
-                    await CompletarLecturaRfidAsync(vm, null);
-                    if (!await vm.ActualizarEstadoAsync("R"))
+
+                    string tagBaseDatos = null;
+                    using (var servicio = new ServicioTransactionClient())
+                    {
+                        tagBaseDatos = await servicio.ObtenerTagAsync(resultadoH.PlacaCamion);
+                    }
+
+                    await CompletarLecturaRfidAsync(vm, tagBaseDatos);
+                    if (await vm.ActualizarEstadoAsync("R") == null)
                         return;
 
                     await EjecutarImpresionAsync(vm);
@@ -213,14 +223,14 @@ namespace ControlesAccesoQR.Views.ControlesAccesoQR
             if (DevBypass.IsDevKiosk)
             {
                 await CompletarImpresionAsync(vm);
-                if (!await vm.ActualizarEstadoAsync("P"))
+                if (await vm.ActualizarEstadoAsync("P") == null)
                     return;
                 MessageBox.Show("Impresión simulada (CGDE041)");
             }
             else
             {
                 await CompletarImpresionAsync(vm);
-                if (!await vm.ActualizarEstadoAsync("P"))
+                if (await vm.ActualizarEstadoAsync("P") == null)
                     return;
                 LimpiarFormularioPostProceso();
             }
@@ -239,11 +249,11 @@ namespace ControlesAccesoQR.Views.ControlesAccesoQR
             return Task.CompletedTask;
         }
 
-        private async Task CompletarLecturaRfidAsync(VistaEntradaSalidaViewModel vm, string tag)
+        private async Task CompletarLecturaRfidAsync(VistaEntradaSalidaViewModel vm, string tagEsperado)
         {
             if (!DevBypass.IsDevKiosk)
             {
-                var rfidOk = await vm.ValidarRfidAsync();
+                var rfidOk = await vm.ValidarRfidAsync(tagEsperado);
                 if (!rfidOk)
                     MessageBox.Show(vm.RfidMensaje, "RFID", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
@@ -252,7 +262,7 @@ namespace ControlesAccesoQR.Views.ControlesAccesoQR
             vm.MainViewModel.Procesos.Add(new Proceso
             {
                 STEP = "RFID",
-                RESPONSE = tag ?? string.Empty,
+                RESPONSE = tagEsperado ?? string.Empty,
                 MESSAGE_ID = 1
             });
         }


### PR DESCRIPTION
## Summary
- Return `ActualizarEstadoResult` so callers can use `PlacaCamion` and store plate in the view model
- Add service-based RFID tag lookup and pass expected tag to antenna validation
- Perform RFID validation after state `H` within `IngresarButton_Click`

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(failed: command not found)*
- `apt-get update` *(failed: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dc46ec688330ae0f407a93c9bd3f