### PR TITLE
Refactor fingerprint dialog to page navigation

### DIFF
--- a/ControlesAccesoQR/ViewModels/ControlesAccesoQR/HuellaViewModel.cs
+++ b/ControlesAccesoQR/ViewModels/ControlesAccesoQR/HuellaViewModel.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Threading.Tasks;
 using System.Windows.Input;
 using RECEPTIO.CapaPresentacion.UI.Biometrico;
 using RECEPTIO.CapaPresentacion.UI.Interfaces.Biometrico;
@@ -33,6 +35,8 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
 
         public ICommand ValidarCommand { get; }
 
+        public event Func<Task> ValidacionCompletada;
+
         public HuellaViewModel(string choferId)
         {
             _choferId = choferId;
@@ -47,6 +51,11 @@ namespace ControlesAccesoQR.ViewModels.ControlesAccesoQR
             HuellaValida = !string.IsNullOrEmpty(Resultado) && Resultado.Contains(_choferId);
             HuellaValida = true;
             Procesando = false;
+        }
+
+        public Task OnValidacionCompletadaAsync()
+        {
+            return ValidacionCompletada?.Invoke() ?? Task.CompletedTask;
         }
     }
 }

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/DialogoHuella.xaml
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/DialogoHuella.xaml
@@ -1,8 +1,9 @@
-<Window x:Class="ControlesAccesoQR.Views.ControlesAccesoQR.DialogoHuella"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Validar Huella" Height="180" Width="300" WindowStartupLocation="CenterOwner"
-        FontFamily="Microsoft Sans Serif">
+<Page x:Class="ControlesAccesoQR.Views.ControlesAccesoQR.DialogoHuella"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      Title="Validar Huella"
+      Height="180" Width="300"
+      FontFamily="Microsoft Sans Serif">
     <StackPanel Margin="10">
         <TextBlock Text="Coloque su dedo en el lector" Margin="0,0,0,10" />
         <TextBlock Text="{Binding Resultado}" TextWrapping="Wrap" Margin="0,0,0,10" />
@@ -11,4 +12,4 @@
             <Button Content="Aceptar" Width="75" Click="Aceptar_Click" IsEnabled="{Binding HuellaValida}" />
         </StackPanel>
     </StackPanel>
-</Window>
+</Page>

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/DialogoHuella.xaml.cs
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/DialogoHuella.xaml.cs
@@ -1,17 +1,25 @@
+using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
+using ControlesAccesoQR.ViewModels.ControlesAccesoQR;
 
 namespace ControlesAccesoQR.Views.ControlesAccesoQR
 {
-    public partial class DialogoHuella : Window
+    public partial class DialogoHuella : Page
     {
         public DialogoHuella()
         {
             InitializeComponent();
         }
 
-        private void Aceptar_Click(object sender, RoutedEventArgs e)
+        private async void Aceptar_Click(object sender, RoutedEventArgs e)
         {
-            DialogResult = true;
+            if (DataContext is HuellaViewModel vm)
+            {
+                await vm.OnValidacionCompletadaAsync();
+            }
+
+            NavigationService?.GoBack();
         }
     }
 }

--- a/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
+++ b/ControlesAccesoQR/Views/ControlesAccesoQR/VistaEntradaSalida.xaml.cs
@@ -190,42 +190,34 @@ namespace ControlesAccesoQR.Views.ControlesAccesoQR
                         await EjecutarImpresionAsync(vm);
                         return;
                     }
-                    var dialogo = new DialogoHuella
+                    var hv = new HuellaViewModel(vm.ChoferID);
+                    hv.ValidacionCompletada += async () =>
                     {
-                        Owner = Window.GetWindow(this),
-                        DataContext = new HuellaViewModel(vm.ChoferID)
-                    };
-
-                    if (dialogo.ShowDialog() == true && dialogo.DataContext is HuellaViewModel hv)
-                    {
-                        // 1) Validación por huella (usa el resultado real del diálogo)
                         await CompletarValidacionHuellaAsync(vm, hv.Resultado, hv.HuellaValida ? 1 : 0);
 
                         if (!hv.HuellaValida)
                             return;
 
-                        // 2) Estado = H (se espera objeto con PlacaCamion, igual a tu flujo actual)
                         var resultadoH = await vm.ActualizarEstadoAsync("H");
                         if (resultadoH == null)
                             return;
 
-                        // 3) Obtener tag desde Transaction (usando la placa del resultado H)
                         string tagBaseDatos = null;
                         using (var servicio = new ServicioTransactionClient())
                         {
                             tagBaseDatos = await servicio.ObtenerTagAsync(resultadoH.PlacaCamion);
                         }
 
-                        // 4) Lectura RFID con tag obtenido
                         await CompletarLecturaRfidAsync(vm, tagBaseDatos);
 
-                        // 5) Estado = R
                         if (await vm.ActualizarEstadoAsync("R") == null)
                             return;
 
-                        // 6) Impresión
                         await EjecutarImpresionAsync(vm);
-                    }
+                    };
+
+                    var frame = (Application.Current.MainWindow as MainWindow)?.MainFrame;
+                    frame?.Navigate(new DialogoHuella { DataContext = hv });
 
                 }
             }


### PR DESCRIPTION
## Summary
- convert fingerprint dialog into a navigable Page and adjust code-behind
- hook up callback-based navigation from entry view through MainFrame
- add completion event in HuellaViewModel to continue flow after validation

## Testing
- `dotnet build ControlesAccesoQR/ControlesAccesoQR.csproj` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b20cc3a5608330914b6d2d582200df